### PR TITLE
Use shared_ptr in AST to clear ASAN warnings

### DIFF
--- a/src/ast/ast.cpp
+++ b/src/ast/ast.cpp
@@ -123,7 +123,9 @@ Call::Call(const std::string &func, std::shared_ptr<ExpressionList> vargs)
 {
 }
 
-Call::Call(const std::string &func, std::shared_ptr<ExpressionList> vargs, location loc)
+Call::Call(const std::string &func,
+           std::shared_ptr<ExpressionList> vargs,
+           location loc)
     : Expression(loc), func(is_deprecated(func)), vargs(vargs)
 {
 }
@@ -144,7 +146,9 @@ Map::Map(const std::string &ident, std::shared_ptr<ExpressionList> vargs)
   is_map = true;
 }
 
-Map::Map(const std::string &ident, std::shared_ptr<ExpressionList> vargs, location loc)
+Map::Map(const std::string &ident,
+         std::shared_ptr<ExpressionList> vargs,
+         location loc)
     : Expression(loc), ident(ident), vargs(vargs)
 {
   is_map = true;
@@ -173,7 +177,10 @@ void Variable::accept(Visitor &v) {
   v.visit(*this);
 }
 
-Binop::Binop(std::shared_ptr<Expression> left, int op, std::shared_ptr<Expression> right, location loc)
+Binop::Binop(std::shared_ptr<Expression> left,
+             int op,
+             std::shared_ptr<Expression> right,
+             location loc)
     : Expression(loc), left(left), right(right), op(op)
 {
 }
@@ -187,7 +194,10 @@ Unop::Unop(int op, std::shared_ptr<Expression> expr, location loc)
 {
 }
 
-Unop::Unop(int op, std::shared_ptr<Expression> expr, bool is_post_op, location loc)
+Unop::Unop(int op,
+           std::shared_ptr<Expression> expr,
+           bool is_post_op,
+           location loc)
     : Expression(loc), expr(expr), op(op), is_post_op(is_post_op)
 {
 }
@@ -196,7 +206,9 @@ void Unop::accept(Visitor &v) {
   v.visit(*this);
 }
 
-Ternary::Ternary(std::shared_ptr<Expression> cond, std::shared_ptr<Expression> left, std::shared_ptr<Expression> right)
+Ternary::Ternary(std::shared_ptr<Expression> cond,
+                 std::shared_ptr<Expression> left,
+                 std::shared_ptr<Expression> right)
     : cond(cond), left(left), right(right)
 {
 }
@@ -213,7 +225,8 @@ void Ternary::accept(Visitor &v) {
   v.visit(*this);
 }
 
-FieldAccess::FieldAccess(std::shared_ptr<Expression> expr, const std::string &field)
+FieldAccess::FieldAccess(std::shared_ptr<Expression> expr,
+                         const std::string &field)
     : expr(expr), field(field)
 {
 }
@@ -225,7 +238,9 @@ FieldAccess::FieldAccess(std::shared_ptr<Expression> expr,
 {
 }
 
-FieldAccess::FieldAccess(std::shared_ptr<Expression> expr, ssize_t index, location loc)
+FieldAccess::FieldAccess(std::shared_ptr<Expression> expr,
+                         ssize_t index,
+                         location loc)
     : Expression(loc), expr(expr), index(index)
 {
 }
@@ -234,12 +249,15 @@ void FieldAccess::accept(Visitor &v) {
   v.visit(*this);
 }
 
-ArrayAccess::ArrayAccess(std::shared_ptr<Expression> expr, std::shared_ptr<Expression> indexpr)
+ArrayAccess::ArrayAccess(std::shared_ptr<Expression> expr,
+                         std::shared_ptr<Expression> indexpr)
     : expr(expr), indexpr(indexpr)
 {
 }
 
-ArrayAccess::ArrayAccess(std::shared_ptr<Expression> expr, std::shared_ptr<Expression> indexpr, location loc)
+ArrayAccess::ArrayAccess(std::shared_ptr<Expression> expr,
+                         std::shared_ptr<Expression> indexpr,
+                         location loc)
     : Expression(loc), expr(expr), indexpr(indexpr)
 {
 }
@@ -248,7 +266,9 @@ void ArrayAccess::accept(Visitor &v) {
   v.visit(*this);
 }
 
-Cast::Cast(const std::string &type, bool is_pointer, std::shared_ptr<Expression> expr)
+Cast::Cast(const std::string &type,
+           bool is_pointer,
+           std::shared_ptr<Expression> expr)
     : cast_type(type), is_pointer(is_pointer), expr(expr)
 {
 }
@@ -292,7 +312,9 @@ void ExprStatement::accept(Visitor &v) {
   v.visit(*this);
 }
 
-AssignMapStatement::AssignMapStatement(std::shared_ptr<Map> map, std::shared_ptr<Expression> expr, location loc)
+AssignMapStatement::AssignMapStatement(std::shared_ptr<Map> map,
+                                       std::shared_ptr<Expression> expr,
+                                       location loc)
     : Statement(loc), map(map), expr(expr)
 {
   expr->map = map;
@@ -302,7 +324,8 @@ void AssignMapStatement::accept(Visitor &v) {
   v.visit(*this);
 }
 
-AssignVarStatement::AssignVarStatement(std::shared_ptr<Variable> var, std::shared_ptr<Expression> expr)
+AssignVarStatement::AssignVarStatement(std::shared_ptr<Variable> var,
+                                       std::shared_ptr<Expression> expr)
     : var(var), expr(expr)
 {
   expr->var = var;
@@ -324,7 +347,8 @@ Predicate::Predicate(std::shared_ptr<Expression> expr) : expr(expr)
 {
 }
 
-Predicate::Predicate(std::shared_ptr<Expression> expr, location loc) : Node(loc), expr(expr)
+Predicate::Predicate(std::shared_ptr<Expression> expr, location loc)
+    : Node(loc), expr(expr)
 {
 }
 
@@ -341,11 +365,14 @@ void AttachPoint::accept(Visitor &v) {
   v.visit(*this);
 }
 
-If::If(std::shared_ptr<Expression> cond, std::shared_ptr<StatementList> stmts) : cond(cond), stmts(stmts)
+If::If(std::shared_ptr<Expression> cond, std::shared_ptr<StatementList> stmts)
+    : cond(cond), stmts(stmts)
 {
 }
 
-If::If(std::shared_ptr<Expression> cond, std::shared_ptr<StatementList> stmts, std::shared_ptr<StatementList> else_stmts)
+If::If(std::shared_ptr<Expression> cond,
+       std::shared_ptr<StatementList> stmts,
+       std::shared_ptr<StatementList> else_stmts)
     : cond(cond), stmts(stmts), else_stmts(else_stmts)
 {
 }
@@ -354,7 +381,9 @@ void If::accept(Visitor &v) {
   v.visit(*this);
 }
 
-Unroll::Unroll(std::shared_ptr<Expression> expr, std::shared_ptr<StatementList> stmts, location loc)
+Unroll::Unroll(std::shared_ptr<Expression> expr,
+               std::shared_ptr<StatementList> stmts,
+               location loc)
     : Statement(loc), expr(expr), stmts(stmts)
 {
 }
@@ -384,7 +413,8 @@ void Probe::accept(Visitor &v) {
   v.visit(*this);
 }
 
-Program::Program(const std::string &c_definitions, std::shared_ptr<ProbeList> probes)
+Program::Program(const std::string &c_definitions,
+                 std::shared_ptr<ProbeList> probes)
     : c_definitions(c_definitions), probes(probes)
 {
 }

--- a/src/ast/ast.cpp
+++ b/src/ast/ast.cpp
@@ -118,12 +118,12 @@ Call::Call(const std::string &func, location loc)
 {
 }
 
-Call::Call(const std::string &func, ExpressionList *vargs)
+Call::Call(const std::string &func, std::shared_ptr<ExpressionList> vargs)
     : func(is_deprecated(func)), vargs(vargs)
 {
 }
 
-Call::Call(const std::string &func, ExpressionList *vargs, location loc)
+Call::Call(const std::string &func, std::shared_ptr<ExpressionList> vargs, location loc)
     : Expression(loc), func(is_deprecated(func)), vargs(vargs)
 {
 }
@@ -138,13 +138,13 @@ Map::Map(const std::string &ident, location loc)
   is_map = true;
 }
 
-Map::Map(const std::string &ident, ExpressionList *vargs)
+Map::Map(const std::string &ident, std::shared_ptr<ExpressionList> vargs)
     : ident(ident), vargs(vargs)
 {
   is_map = true;
 }
 
-Map::Map(const std::string &ident, ExpressionList *vargs, location loc)
+Map::Map(const std::string &ident, std::shared_ptr<ExpressionList> vargs, location loc)
     : Expression(loc), ident(ident), vargs(vargs)
 {
   is_map = true;
@@ -173,7 +173,7 @@ void Variable::accept(Visitor &v) {
   v.visit(*this);
 }
 
-Binop::Binop(Expression *left, int op, Expression *right, location loc)
+Binop::Binop(std::shared_ptr<Expression> left, int op, std::shared_ptr<Expression> right, location loc)
     : Expression(loc), left(left), right(right), op(op)
 {
 }
@@ -182,12 +182,12 @@ void Binop::accept(Visitor &v) {
   v.visit(*this);
 }
 
-Unop::Unop(int op, Expression *expr, location loc)
+Unop::Unop(int op, std::shared_ptr<Expression> expr, location loc)
     : Expression(loc), expr(expr), op(op), is_post_op(false)
 {
 }
 
-Unop::Unop(int op, Expression *expr, bool is_post_op, location loc)
+Unop::Unop(int op, std::shared_ptr<Expression> expr, bool is_post_op, location loc)
     : Expression(loc), expr(expr), op(op), is_post_op(is_post_op)
 {
 }
@@ -196,14 +196,14 @@ void Unop::accept(Visitor &v) {
   v.visit(*this);
 }
 
-Ternary::Ternary(Expression *cond, Expression *left, Expression *right)
+Ternary::Ternary(std::shared_ptr<Expression> cond, std::shared_ptr<Expression> left, std::shared_ptr<Expression> right)
     : cond(cond), left(left), right(right)
 {
 }
 
-Ternary::Ternary(Expression *cond,
-                 Expression *left,
-                 Expression *right,
+Ternary::Ternary(std::shared_ptr<Expression> cond,
+                 std::shared_ptr<Expression> left,
+                 std::shared_ptr<Expression> right,
                  location loc)
     : Expression(loc), cond(cond), left(left), right(right)
 {
@@ -213,19 +213,19 @@ void Ternary::accept(Visitor &v) {
   v.visit(*this);
 }
 
-FieldAccess::FieldAccess(Expression *expr, const std::string &field)
+FieldAccess::FieldAccess(std::shared_ptr<Expression> expr, const std::string &field)
     : expr(expr), field(field)
 {
 }
 
-FieldAccess::FieldAccess(Expression *expr,
+FieldAccess::FieldAccess(std::shared_ptr<Expression> expr,
                          const std::string &field,
                          location loc)
     : Expression(loc), expr(expr), field(field)
 {
 }
 
-FieldAccess::FieldAccess(Expression *expr, ssize_t index, location loc)
+FieldAccess::FieldAccess(std::shared_ptr<Expression> expr, ssize_t index, location loc)
     : Expression(loc), expr(expr), index(index)
 {
 }
@@ -234,12 +234,12 @@ void FieldAccess::accept(Visitor &v) {
   v.visit(*this);
 }
 
-ArrayAccess::ArrayAccess(Expression *expr, Expression *indexpr)
+ArrayAccess::ArrayAccess(std::shared_ptr<Expression> expr, std::shared_ptr<Expression> indexpr)
     : expr(expr), indexpr(indexpr)
 {
 }
 
-ArrayAccess::ArrayAccess(Expression *expr, Expression *indexpr, location loc)
+ArrayAccess::ArrayAccess(std::shared_ptr<Expression> expr, std::shared_ptr<Expression> indexpr, location loc)
     : Expression(loc), expr(expr), indexpr(indexpr)
 {
 }
@@ -248,14 +248,14 @@ void ArrayAccess::accept(Visitor &v) {
   v.visit(*this);
 }
 
-Cast::Cast(const std::string &type, bool is_pointer, Expression *expr)
+Cast::Cast(const std::string &type, bool is_pointer, std::shared_ptr<Expression> expr)
     : cast_type(type), is_pointer(is_pointer), expr(expr)
 {
 }
 
 Cast::Cast(const std::string &type,
            bool is_pointer,
-           Expression *expr,
+           std::shared_ptr<Expression> expr,
            location loc)
     : Expression(loc), cast_type(type), is_pointer(is_pointer), expr(expr)
 {
@@ -265,7 +265,7 @@ void Cast::accept(Visitor &v) {
   v.visit(*this);
 }
 
-Tuple::Tuple(ExpressionList *elems, location loc)
+Tuple::Tuple(std::shared_ptr<ExpressionList> elems, location loc)
     : Expression(loc), elems(elems)
 {
 }
@@ -279,11 +279,11 @@ Statement::Statement(location loc) : Node(loc)
 {
 }
 
-ExprStatement::ExprStatement(Expression *expr) : expr(expr)
+ExprStatement::ExprStatement(std::shared_ptr<Expression> expr) : expr(expr)
 {
 }
 
-ExprStatement::ExprStatement(Expression *expr, location loc)
+ExprStatement::ExprStatement(std::shared_ptr<Expression> expr, location loc)
     : Statement(loc), expr(expr)
 {
 }
@@ -292,7 +292,7 @@ void ExprStatement::accept(Visitor &v) {
   v.visit(*this);
 }
 
-AssignMapStatement::AssignMapStatement(Map *map, Expression *expr, location loc)
+AssignMapStatement::AssignMapStatement(std::shared_ptr<Map> map, std::shared_ptr<Expression> expr, location loc)
     : Statement(loc), map(map), expr(expr)
 {
   expr->map = map;
@@ -302,14 +302,14 @@ void AssignMapStatement::accept(Visitor &v) {
   v.visit(*this);
 }
 
-AssignVarStatement::AssignVarStatement(Variable *var, Expression *expr)
+AssignVarStatement::AssignVarStatement(std::shared_ptr<Variable> var, std::shared_ptr<Expression> expr)
     : var(var), expr(expr)
 {
   expr->var = var;
 }
 
-AssignVarStatement::AssignVarStatement(Variable *var,
-                                       Expression *expr,
+AssignVarStatement::AssignVarStatement(std::shared_ptr<Variable> var,
+                                       std::shared_ptr<Expression> expr,
                                        location loc)
     : Statement(loc), var(var), expr(expr)
 {
@@ -320,11 +320,11 @@ void AssignVarStatement::accept(Visitor &v) {
   v.visit(*this);
 }
 
-Predicate::Predicate(Expression *expr) : expr(expr)
+Predicate::Predicate(std::shared_ptr<Expression> expr) : expr(expr)
 {
 }
 
-Predicate::Predicate(Expression *expr, location loc) : Node(loc), expr(expr)
+Predicate::Predicate(std::shared_ptr<Expression> expr, location loc) : Node(loc), expr(expr)
 {
 }
 
@@ -341,11 +341,11 @@ void AttachPoint::accept(Visitor &v) {
   v.visit(*this);
 }
 
-If::If(Expression *cond, StatementList *stmts) : cond(cond), stmts(stmts)
+If::If(std::shared_ptr<Expression> cond, std::shared_ptr<StatementList> stmts) : cond(cond), stmts(stmts)
 {
 }
 
-If::If(Expression *cond, StatementList *stmts, StatementList *else_stmts)
+If::If(std::shared_ptr<Expression> cond, std::shared_ptr<StatementList> stmts, std::shared_ptr<StatementList> else_stmts)
     : cond(cond), stmts(stmts), else_stmts(else_stmts)
 {
 }
@@ -354,7 +354,7 @@ void If::accept(Visitor &v) {
   v.visit(*this);
 }
 
-Unroll::Unroll(Expression *expr, StatementList *stmts, location loc)
+Unroll::Unroll(std::shared_ptr<Expression> expr, std::shared_ptr<StatementList> stmts, location loc)
     : Statement(loc), expr(expr), stmts(stmts)
 {
 }
@@ -363,9 +363,9 @@ void Unroll::accept(Visitor &v) {
   v.visit(*this);
 }
 
-Probe::Probe(AttachPointList *attach_points,
-             Predicate *pred,
-             StatementList *stmts)
+Probe::Probe(std::shared_ptr<AttachPointList> attach_points,
+             std::shared_ptr<Predicate> pred,
+             std::shared_ptr<StatementList> stmts)
     : attach_points(attach_points), pred(pred), stmts(stmts)
 {
 }
@@ -384,7 +384,7 @@ void Probe::accept(Visitor &v) {
   v.visit(*this);
 }
 
-Program::Program(const std::string &c_definitions, ProbeList *probes)
+Program::Program(const std::string &c_definitions, std::shared_ptr<ProbeList> probes)
     : c_definitions(c_definitions), probes(probes)
 {
 }

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -31,13 +31,13 @@ public:
   Expression(location loc);
   SizedType type;
   Map *key_for_map = nullptr;
-  Map *map = nullptr; // Only set when this expression is assigned to a map
-  Variable *var = nullptr; // Set when this expression is assigned to a variable
+  std::shared_ptr<Map> map = nullptr; // Only set when this expression is assigned to a map
+  std::shared_ptr<Variable> var = nullptr; // Set when this expression is assigned to a variable
   bool is_literal = false;
   bool is_variable = false;
   bool is_map = false;
 };
-using ExpressionList = std::vector<Expression *>;
+using ExpressionList = std::vector<std::shared_ptr<Expression> >;
 
 class Integer : public Expression {
 public:
@@ -102,10 +102,10 @@ class Call : public Expression {
 public:
   explicit Call(const std::string &func);
   explicit Call(const std::string &func, location loc);
-  Call(const std::string &func, ExpressionList *vargs);
-  Call(const std::string &func, ExpressionList *vargs, location loc);
+  Call(const std::string &func, std::shared_ptr<ExpressionList> vargs);
+  Call(const std::string &func, std::shared_ptr<ExpressionList> vargs, location loc);
   std::string func;
-  ExpressionList *vargs;
+  std::shared_ptr<ExpressionList> vargs;
 
   void accept(Visitor &v) override;
 };
@@ -113,10 +113,10 @@ public:
 class Map : public Expression {
 public:
   explicit Map(const std::string &ident, location loc);
-  Map(const std::string &ident, ExpressionList *vargs);
-  Map(const std::string &ident, ExpressionList *vargs, location loc);
+  Map(const std::string &ident, std::shared_ptr<ExpressionList> vargs);
+  Map(const std::string &ident, std::shared_ptr<ExpressionList> vargs, location loc);
   std::string ident;
-  ExpressionList *vargs;
+  std::shared_ptr<ExpressionList> vargs;
   bool skip_key_validation = false;
 
   void accept(Visitor &v) override;
@@ -133,8 +133,8 @@ public:
 
 class Binop : public Expression {
 public:
-  Binop(Expression *left, int op, Expression *right, location loc);
-  Expression *left, *right;
+  Binop(std::shared_ptr<Expression> left, int op, std::shared_ptr<Expression> right, location loc);
+  std::shared_ptr<Expression> left, right;
   int op;
 
   void accept(Visitor &v) override;
@@ -142,12 +142,12 @@ public:
 
 class Unop : public Expression {
 public:
-  Unop(int op, Expression *expr, location loc = location());
+  Unop(int op, std::shared_ptr<Expression> expr, location loc = location());
   Unop(int op,
-       Expression *expr,
+       std::shared_ptr<Expression> expr,
        bool is_post_op = false,
        location loc = location());
-  Expression *expr;
+  std::shared_ptr<Expression> expr;
   int op;
   bool is_post_op;
 
@@ -156,10 +156,10 @@ public:
 
 class FieldAccess : public Expression {
 public:
-  FieldAccess(Expression *expr, const std::string &field);
-  FieldAccess(Expression *expr, const std::string &field, location loc);
-  FieldAccess(Expression *expr, ssize_t index, location loc);
-  Expression *expr;
+  FieldAccess(std::shared_ptr<Expression> expr, const std::string &field);
+  FieldAccess(std::shared_ptr<Expression> expr, const std::string &field, location loc);
+  FieldAccess(std::shared_ptr<Expression> expr, ssize_t index, location loc);
+  std::shared_ptr<Expression> expr;
   std::string field;
   ssize_t index = -1;
 
@@ -168,24 +168,24 @@ public:
 
 class ArrayAccess : public Expression {
 public:
-  ArrayAccess(Expression *expr, Expression *indexpr);
-  ArrayAccess(Expression *expr, Expression *indexpr, location loc);
-  Expression *expr;
-  Expression *indexpr;
+  ArrayAccess(std::shared_ptr<Expression> expr, std::shared_ptr<Expression> indexpr);
+  ArrayAccess(std::shared_ptr<Expression> expr, std::shared_ptr<Expression> indexpr, location loc);
+  std::shared_ptr<Expression> expr;
+  std::shared_ptr<Expression> indexpr;
 
   void accept(Visitor &v) override;
 };
 
 class Cast : public Expression {
 public:
-  Cast(const std::string &type, bool is_pointer, Expression *expr);
+  Cast(const std::string &type, bool is_pointer, std::shared_ptr<Expression> expr);
   Cast(const std::string &type,
        bool is_pointer,
-       Expression *expr,
+       std::shared_ptr<Expression> expr,
        location loc);
   std::string cast_type;
   bool is_pointer;
-  Expression *expr;
+  std::shared_ptr<Expression> expr;
 
   void accept(Visitor &v) override;
 };
@@ -193,8 +193,8 @@ public:
 class Tuple : public Expression
 {
 public:
-  Tuple(ExpressionList *elems, location loc);
-  ExpressionList *elems;
+  Tuple(std::shared_ptr<ExpressionList> elems, location loc);
+  std::shared_ptr<ExpressionList> elems;
 
   void accept(Visitor &v) override;
 };
@@ -204,53 +204,53 @@ public:
   Statement() = default;
   Statement(location loc);
 };
-using StatementList = std::vector<Statement *>;
+using StatementList = std::vector<std::shared_ptr<Statement> >;
 
 class ExprStatement : public Statement {
 public:
-  explicit ExprStatement(Expression *expr);
-  explicit ExprStatement(Expression *expr, location loc);
-  Expression *expr;
+  explicit ExprStatement(std::shared_ptr<Expression> expr);
+  explicit ExprStatement(std::shared_ptr<Expression> expr, location loc);
+  std::shared_ptr<Expression> expr;
 
   void accept(Visitor &v) override;
 };
 
 class AssignMapStatement : public Statement {
 public:
-  AssignMapStatement(Map *map, Expression *expr, location loc = location());
-  Map *map;
-  Expression *expr;
+  AssignMapStatement(std::shared_ptr<Map> map, std::shared_ptr<Expression> expr, location loc = location());
+  std::shared_ptr<Map> map;
+  std::shared_ptr<Expression> expr;
 
   void accept(Visitor &v) override;
 };
 
 class AssignVarStatement : public Statement {
 public:
-  AssignVarStatement(Variable *var, Expression *expr);
-  AssignVarStatement(Variable *var, Expression *expr, location loc);
-  Variable *var;
-  Expression *expr;
+  AssignVarStatement(std::shared_ptr<Variable> var, std::shared_ptr<Expression> expr);
+  AssignVarStatement(std::shared_ptr<Variable> var, std::shared_ptr<Expression> expr, location loc);
+  std::shared_ptr<Variable> var;
+  std::shared_ptr<Expression> expr;
 
   void accept(Visitor &v) override;
 };
 
 class If : public Statement {
 public:
-  If(Expression *cond, StatementList *stmts);
-  If(Expression *cond, StatementList *stmts, StatementList *else_stmts);
-  Expression *cond;
-  StatementList *stmts = nullptr;
-  StatementList *else_stmts = nullptr;
+  If(std::shared_ptr<Expression> cond, std::shared_ptr<StatementList> stmts);
+  If(std::shared_ptr<Expression> cond, std::shared_ptr<StatementList> stmts, std::shared_ptr<StatementList> else_stmts);
+  std::shared_ptr<Expression> cond;
+  std::shared_ptr<StatementList> stmts = nullptr;
+  std::shared_ptr<StatementList> else_stmts = nullptr;
 
   void accept(Visitor &v) override;
 };
 
 class Unroll : public Statement {
 public:
-  Unroll(Expression *expr, StatementList *stmts, location loc);
+  Unroll(std::shared_ptr<Expression> expr, std::shared_ptr<StatementList> stmts, location loc);
   long int var = 0;
-  Expression *expr;
-  StatementList *stmts;
+  std::shared_ptr<Expression> expr;
+  std::shared_ptr<StatementList> stmts;
 
   void accept(Visitor &v) override;
 };
@@ -270,18 +270,18 @@ public:
 
 class Predicate : public Node {
 public:
-  explicit Predicate(Expression *expr);
-  explicit Predicate(Expression *expr, location loc);
-  Expression *expr;
+  explicit Predicate(std::shared_ptr<Expression> expr);
+  explicit Predicate(std::shared_ptr<Expression> expr, location loc);
+  std::shared_ptr<Expression> expr;
 
   void accept(Visitor &v) override;
 };
 
 class Ternary : public Expression {
 public:
-  Ternary(Expression *cond, Expression *left, Expression *right);
-  Ternary(Expression *cond, Expression *left, Expression *right, location loc);
-  Expression *cond, *left, *right;
+  Ternary(std::shared_ptr<Expression> cond, std::shared_ptr<Expression> left, std::shared_ptr<Expression> right);
+  Ternary(std::shared_ptr<Expression> cond, std::shared_ptr<Expression> left, std::shared_ptr<Expression> right, location loc);
+  std::shared_ptr<Expression> cond, left, right;
 
   void accept(Visitor &v) override;
 };
@@ -289,12 +289,12 @@ public:
 class While : public Statement
 {
 public:
-  While(Expression *cond, StatementList *stmts, location loc)
+  While(std::shared_ptr<Expression> cond, std::shared_ptr<StatementList> stmts, location loc)
       : cond(cond), stmts(stmts), loc(loc)
   {
   }
-  Expression *cond;
-  StatementList *stmts = nullptr;
+  std::shared_ptr<Expression> cond;
+  std::shared_ptr<StatementList> stmts = nullptr;
   location loc;
 
   void accept(Visitor &v) override;
@@ -329,15 +329,15 @@ public:
 private:
   std::map<std::string, int> index_;
 };
-using AttachPointList = std::vector<AttachPoint *>;
+using AttachPointList = std::vector<std::shared_ptr<AttachPoint>>;
 
 class Probe : public Node {
 public:
-  Probe(AttachPointList *attach_points, Predicate *pred, StatementList *stmts);
+  Probe(std::shared_ptr<AttachPointList> attach_points, std::shared_ptr<Predicate> pred, std::shared_ptr<StatementList> stmts);
 
-  AttachPointList *attach_points;
-  Predicate *pred;
-  StatementList *stmts;
+  std::shared_ptr<AttachPointList> attach_points;
+  std::shared_ptr<Predicate> pred;
+  std::shared_ptr<StatementList> stmts;
 
   void accept(Visitor &v) override;
   std::string name() const;
@@ -349,13 +349,13 @@ public:
 private:
   int index_ = 0;
 };
-using ProbeList = std::vector<Probe *>;
+using ProbeList = std::vector<std::shared_ptr<Probe>>;
 
 class Program : public Node {
 public:
-  Program(const std::string &c_definitions, ProbeList *probes);
+  Program(const std::string &c_definitions, std::shared_ptr<ProbeList> probes);
   std::string c_definitions;
-  ProbeList *probes;
+  std::shared_ptr<ProbeList> probes;
 
   void accept(Visitor &v) override;
 };

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -31,13 +31,15 @@ public:
   Expression(location loc);
   SizedType type;
   Map *key_for_map = nullptr;
-  std::shared_ptr<Map> map = nullptr; // Only set when this expression is assigned to a map
-  std::shared_ptr<Variable> var = nullptr; // Set when this expression is assigned to a variable
+  std::shared_ptr<Map> map = nullptr;      // Only set when this expression is
+                                           // assigned to a map
+  std::shared_ptr<Variable> var = nullptr; // Set when this expression is
+                                           // assigned to a variable
   bool is_literal = false;
   bool is_variable = false;
   bool is_map = false;
 };
-using ExpressionList = std::vector<std::shared_ptr<Expression> >;
+using ExpressionList = std::vector<std::shared_ptr<Expression>>;
 
 class Integer : public Expression {
 public:
@@ -103,7 +105,9 @@ public:
   explicit Call(const std::string &func);
   explicit Call(const std::string &func, location loc);
   Call(const std::string &func, std::shared_ptr<ExpressionList> vargs);
-  Call(const std::string &func, std::shared_ptr<ExpressionList> vargs, location loc);
+  Call(const std::string &func,
+       std::shared_ptr<ExpressionList> vargs,
+       location loc);
   std::string func;
   std::shared_ptr<ExpressionList> vargs;
 
@@ -114,7 +118,9 @@ class Map : public Expression {
 public:
   explicit Map(const std::string &ident, location loc);
   Map(const std::string &ident, std::shared_ptr<ExpressionList> vargs);
-  Map(const std::string &ident, std::shared_ptr<ExpressionList> vargs, location loc);
+  Map(const std::string &ident,
+      std::shared_ptr<ExpressionList> vargs,
+      location loc);
   std::string ident;
   std::shared_ptr<ExpressionList> vargs;
   bool skip_key_validation = false;
@@ -133,7 +139,10 @@ public:
 
 class Binop : public Expression {
 public:
-  Binop(std::shared_ptr<Expression> left, int op, std::shared_ptr<Expression> right, location loc);
+  Binop(std::shared_ptr<Expression> left,
+        int op,
+        std::shared_ptr<Expression> right,
+        location loc);
   std::shared_ptr<Expression> left, right;
   int op;
 
@@ -157,7 +166,9 @@ public:
 class FieldAccess : public Expression {
 public:
   FieldAccess(std::shared_ptr<Expression> expr, const std::string &field);
-  FieldAccess(std::shared_ptr<Expression> expr, const std::string &field, location loc);
+  FieldAccess(std::shared_ptr<Expression> expr,
+              const std::string &field,
+              location loc);
   FieldAccess(std::shared_ptr<Expression> expr, ssize_t index, location loc);
   std::shared_ptr<Expression> expr;
   std::string field;
@@ -168,8 +179,11 @@ public:
 
 class ArrayAccess : public Expression {
 public:
-  ArrayAccess(std::shared_ptr<Expression> expr, std::shared_ptr<Expression> indexpr);
-  ArrayAccess(std::shared_ptr<Expression> expr, std::shared_ptr<Expression> indexpr, location loc);
+  ArrayAccess(std::shared_ptr<Expression> expr,
+              std::shared_ptr<Expression> indexpr);
+  ArrayAccess(std::shared_ptr<Expression> expr,
+              std::shared_ptr<Expression> indexpr,
+              location loc);
   std::shared_ptr<Expression> expr;
   std::shared_ptr<Expression> indexpr;
 
@@ -178,7 +192,9 @@ public:
 
 class Cast : public Expression {
 public:
-  Cast(const std::string &type, bool is_pointer, std::shared_ptr<Expression> expr);
+  Cast(const std::string &type,
+       bool is_pointer,
+       std::shared_ptr<Expression> expr);
   Cast(const std::string &type,
        bool is_pointer,
        std::shared_ptr<Expression> expr,
@@ -204,7 +220,7 @@ public:
   Statement() = default;
   Statement(location loc);
 };
-using StatementList = std::vector<std::shared_ptr<Statement> >;
+using StatementList = std::vector<std::shared_ptr<Statement>>;
 
 class ExprStatement : public Statement {
 public:
@@ -217,7 +233,9 @@ public:
 
 class AssignMapStatement : public Statement {
 public:
-  AssignMapStatement(std::shared_ptr<Map> map, std::shared_ptr<Expression> expr, location loc = location());
+  AssignMapStatement(std::shared_ptr<Map> map,
+                     std::shared_ptr<Expression> expr,
+                     location loc = location());
   std::shared_ptr<Map> map;
   std::shared_ptr<Expression> expr;
 
@@ -226,8 +244,11 @@ public:
 
 class AssignVarStatement : public Statement {
 public:
-  AssignVarStatement(std::shared_ptr<Variable> var, std::shared_ptr<Expression> expr);
-  AssignVarStatement(std::shared_ptr<Variable> var, std::shared_ptr<Expression> expr, location loc);
+  AssignVarStatement(std::shared_ptr<Variable> var,
+                     std::shared_ptr<Expression> expr);
+  AssignVarStatement(std::shared_ptr<Variable> var,
+                     std::shared_ptr<Expression> expr,
+                     location loc);
   std::shared_ptr<Variable> var;
   std::shared_ptr<Expression> expr;
 
@@ -237,7 +258,9 @@ public:
 class If : public Statement {
 public:
   If(std::shared_ptr<Expression> cond, std::shared_ptr<StatementList> stmts);
-  If(std::shared_ptr<Expression> cond, std::shared_ptr<StatementList> stmts, std::shared_ptr<StatementList> else_stmts);
+  If(std::shared_ptr<Expression> cond,
+     std::shared_ptr<StatementList> stmts,
+     std::shared_ptr<StatementList> else_stmts);
   std::shared_ptr<Expression> cond;
   std::shared_ptr<StatementList> stmts = nullptr;
   std::shared_ptr<StatementList> else_stmts = nullptr;
@@ -247,7 +270,9 @@ public:
 
 class Unroll : public Statement {
 public:
-  Unroll(std::shared_ptr<Expression> expr, std::shared_ptr<StatementList> stmts, location loc);
+  Unroll(std::shared_ptr<Expression> expr,
+         std::shared_ptr<StatementList> stmts,
+         location loc);
   long int var = 0;
   std::shared_ptr<Expression> expr;
   std::shared_ptr<StatementList> stmts;
@@ -279,8 +304,13 @@ public:
 
 class Ternary : public Expression {
 public:
-  Ternary(std::shared_ptr<Expression> cond, std::shared_ptr<Expression> left, std::shared_ptr<Expression> right);
-  Ternary(std::shared_ptr<Expression> cond, std::shared_ptr<Expression> left, std::shared_ptr<Expression> right, location loc);
+  Ternary(std::shared_ptr<Expression> cond,
+          std::shared_ptr<Expression> left,
+          std::shared_ptr<Expression> right);
+  Ternary(std::shared_ptr<Expression> cond,
+          std::shared_ptr<Expression> left,
+          std::shared_ptr<Expression> right,
+          location loc);
   std::shared_ptr<Expression> cond, left, right;
 
   void accept(Visitor &v) override;
@@ -289,7 +319,9 @@ public:
 class While : public Statement
 {
 public:
-  While(std::shared_ptr<Expression> cond, std::shared_ptr<StatementList> stmts, location loc)
+  While(std::shared_ptr<Expression> cond,
+        std::shared_ptr<StatementList> stmts,
+        location loc)
       : cond(cond), stmts(stmts), loc(loc)
   {
   }
@@ -333,7 +365,9 @@ using AttachPointList = std::vector<std::shared_ptr<AttachPoint>>;
 
 class Probe : public Node {
 public:
-  Probe(std::shared_ptr<AttachPointList> attach_points, std::shared_ptr<Predicate> pred, std::shared_ptr<StatementList> stmts);
+  Probe(std::shared_ptr<AttachPointList> attach_points,
+        std::shared_ptr<Predicate> pred,
+        std::shared_ptr<StatementList> stmts);
 
   std::shared_ptr<AttachPointList> attach_points;
   std::shared_ptr<Predicate> pred;

--- a/src/ast/attachpoint_parser.cpp
+++ b/src/ast/attachpoint_parser.cpp
@@ -13,7 +13,7 @@
 namespace bpftrace {
 namespace ast {
 
-AttachPointParser::AttachPointParser(Program *root,
+AttachPointParser::AttachPointParser(std::shared_ptr<Program> root,
                                      BPFtrace &bpftrace,
                                      std::ostream &sink)
     : root_(root), bpftrace_(bpftrace), sink_(sink)
@@ -26,9 +26,9 @@ int AttachPointParser::parse()
     return 1;
 
   uint32_t failed = 0;
-  for (Probe *probe : *(root_->probes))
+  for (std::shared_ptr<Probe> probe : *(root_->probes))
   {
-    for (AttachPoint *ap : *(probe->attach_points))
+    for (std::shared_ptr<AttachPoint> ap : *(probe->attach_points))
     {
       if (parse_attachpoint(*ap))
       {

--- a/src/ast/attachpoint_parser.h
+++ b/src/ast/attachpoint_parser.h
@@ -13,7 +13,7 @@ namespace ast {
 class AttachPointParser
 {
 public:
-  AttachPointParser(Program *root, BPFtrace &bpftrace, std::ostream &sink);
+  AttachPointParser(std::shared_ptr<Program> root, BPFtrace &bpftrace, std::ostream &sink);
   ~AttachPointParser() = default;
   int parse();
 
@@ -46,7 +46,7 @@ private:
   int watchpoint_parser();
   int kfunc_parser();
 
-  Program *root_{ nullptr }; // Non-owning pointer
+  std::shared_ptr<Program> root_;
   BPFtrace &bpftrace_;
   std::ostream &sink_;
   AttachPoint *ap_{ nullptr }; // Non-owning pointer

--- a/src/ast/attachpoint_parser.h
+++ b/src/ast/attachpoint_parser.h
@@ -13,7 +13,9 @@ namespace ast {
 class AttachPointParser
 {
 public:
-  AttachPointParser(std::shared_ptr<Program> root, BPFtrace &bpftrace, std::ostream &sink);
+  AttachPointParser(std::shared_ptr<Program> root,
+                    BPFtrace &bpftrace,
+                    std::ostream &sink);
   ~AttachPointParser() = default;
   int parse();
 

--- a/src/ast/codegen_llvm.cpp
+++ b/src/ast/codegen_llvm.cpp
@@ -2255,7 +2255,8 @@ AllocaInst *CodegenLLVM::getHistMapKey(Map &map, Value *log2)
     key = b_.CreateAllocaBPF(size, map.ident + "_key");
 
     int offset = 0;
-    for (std::shared_ptr<Expression> expr : *map.vargs) {
+    for (std::shared_ptr<Expression> expr : *map.vargs)
+    {
       auto scoped_del = accept(expr);
       Value *offset_val = b_.CreateGEP(key, {b_.getInt64(0), b_.getInt64(offset)});
       if (shouldBeOnStackAlready(expr->type))

--- a/src/ast/codegen_llvm.h
+++ b/src/ast/codegen_llvm.h
@@ -22,7 +22,7 @@ using CallArgs = std::vector<std::tuple<std::string, std::vector<Field>>>;
 
 class CodegenLLVM : public Visitor {
 public:
-  explicit CodegenLLVM(Node *root, BPFtrace &bpftrace);
+  explicit CodegenLLVM(std::shared_ptr<Node> root, BPFtrace &bpftrace);
 
   void visit(Integer &integer) override;
   void visit(PositionalParameter &param) override;
@@ -105,14 +105,14 @@ private:
                      const std::string &section_name,
                      FunctionType *func_type,
                      bool expansion);
-  [[nodiscard]] ScopedExprDeleter accept(Node *node);
+  [[nodiscard]] ScopedExprDeleter accept(std::shared_ptr<Node> node);
 
   void compareStructure(SizedType &our_type, llvm::Type *llvm_type);
 
   Function *createLog2Function();
   Function *createLinearFunction();
 
-  Node *root_;
+  std::shared_ptr<Node> root_;
   LLVMContext context_;
   std::unique_ptr<Module> module_;
   std::unique_ptr<ExecutionEngine> ee_;
@@ -122,7 +122,7 @@ private:
   Value *expr_ = nullptr;
   std::function<void()> expr_deleter_; // intentionally empty
   Value *ctx_;
-  AttachPoint *current_attach_point_ = nullptr;
+  std::shared_ptr<AttachPoint> current_attach_point_ = nullptr;
   BPFtrace &bpftrace_;
   std::string probefull_;
   std::string tracepoint_struct_;

--- a/src/ast/field_analyser.cpp
+++ b/src/ast/field_analyser.cpp
@@ -86,7 +86,7 @@ void FieldAnalyser::visit(Builtin &builtin)
 void FieldAnalyser::visit(Call &call)
 {
   if (call.vargs) {
-    for (Expression *expr : *call.vargs) {
+    for (std::shared_ptr<Expression> expr : *call.vargs) {
       expr->accept(*this);
     }
   }
@@ -96,7 +96,7 @@ void FieldAnalyser::visit(Map &map)
 {
   MapKey key;
   if (map.vargs) {
-    for (Expression *expr : *map.vargs) {
+    for (std::shared_ptr<Expression> expr : *map.vargs) {
       expr->accept(*this);
     }
   }
@@ -141,7 +141,7 @@ void FieldAnalyser::visit(While &while_block)
 {
   while_block.cond->accept(*this);
 
-  for (Statement *stmt : *while_block.stmts)
+  for (std::shared_ptr<Statement> stmt : *while_block.stmts)
   {
     stmt->accept(*this);
   }
@@ -151,12 +151,12 @@ void FieldAnalyser::visit(If &if_block)
 {
   if_block.cond->accept(*this);
 
-  for (Statement *stmt : *if_block.stmts) {
+  for (std::shared_ptr<Statement> stmt : *if_block.stmts) {
     stmt->accept(*this);
   }
 
   if (if_block.else_stmts) {
-    for (Statement *stmt : *if_block.else_stmts) {
+    for (std::shared_ptr<Statement> stmt : *if_block.else_stmts) {
       stmt->accept(*this);
     }
   }
@@ -165,7 +165,7 @@ void FieldAnalyser::visit(If &if_block)
 void FieldAnalyser::visit(Unroll &unroll)
 {
   // visit statements in unroll once
-  for (Statement *stmt : *unroll.stmts)
+  for (std::shared_ptr<Statement> stmt : *unroll.stmts)
   {
     stmt->accept(*this);
   }
@@ -213,7 +213,7 @@ void FieldAnalyser::visit(Cast &cast)
 
 void FieldAnalyser::visit(Tuple &tuple)
 {
-  for (Expression *expr : *tuple.elems)
+  for (std::shared_ptr<Expression> expr : *tuple.elems)
     expr->accept(*this);
 }
 
@@ -374,7 +374,7 @@ void FieldAnalyser::visit(Probe &probe)
   has_mixed_args_ = false;
   probe_ = &probe;
 
-  for (AttachPoint *ap : *probe.attach_points) {
+  for (std::shared_ptr<AttachPoint> ap : *probe.attach_points) {
     ap->accept(*this);
     ProbeType pt = probetype(ap->provider);
     prog_type_ = progtype(pt);
@@ -382,14 +382,14 @@ void FieldAnalyser::visit(Probe &probe)
   if (probe.pred) {
     probe.pred->accept(*this);
   }
-  for (Statement *stmt : *probe.stmts) {
+  for (std::shared_ptr<Statement> stmt : *probe.stmts) {
     stmt->accept(*this);
   }
 }
 
 void FieldAnalyser::visit(Program &program)
 {
-  for (Probe *probe : *program.probes)
+  for (std::shared_ptr<Probe> probe : *program.probes)
     probe->accept(*this);
 }
 

--- a/src/ast/field_analyser.cpp
+++ b/src/ast/field_analyser.cpp
@@ -86,7 +86,8 @@ void FieldAnalyser::visit(Builtin &builtin)
 void FieldAnalyser::visit(Call &call)
 {
   if (call.vargs) {
-    for (std::shared_ptr<Expression> expr : *call.vargs) {
+    for (std::shared_ptr<Expression> expr : *call.vargs)
+    {
       expr->accept(*this);
     }
   }
@@ -96,7 +97,8 @@ void FieldAnalyser::visit(Map &map)
 {
   MapKey key;
   if (map.vargs) {
-    for (std::shared_ptr<Expression> expr : *map.vargs) {
+    for (std::shared_ptr<Expression> expr : *map.vargs)
+    {
       expr->accept(*this);
     }
   }
@@ -151,12 +153,14 @@ void FieldAnalyser::visit(If &if_block)
 {
   if_block.cond->accept(*this);
 
-  for (std::shared_ptr<Statement> stmt : *if_block.stmts) {
+  for (std::shared_ptr<Statement> stmt : *if_block.stmts)
+  {
     stmt->accept(*this);
   }
 
   if (if_block.else_stmts) {
-    for (std::shared_ptr<Statement> stmt : *if_block.else_stmts) {
+    for (std::shared_ptr<Statement> stmt : *if_block.else_stmts)
+    {
       stmt->accept(*this);
     }
   }
@@ -374,7 +378,8 @@ void FieldAnalyser::visit(Probe &probe)
   has_mixed_args_ = false;
   probe_ = &probe;
 
-  for (std::shared_ptr<AttachPoint> ap : *probe.attach_points) {
+  for (std::shared_ptr<AttachPoint> ap : *probe.attach_points)
+  {
     ap->accept(*this);
     ProbeType pt = probetype(ap->provider);
     prog_type_ = progtype(pt);
@@ -382,7 +387,8 @@ void FieldAnalyser::visit(Probe &probe)
   if (probe.pred) {
     probe.pred->accept(*this);
   }
-  for (std::shared_ptr<Statement> stmt : *probe.stmts) {
+  for (std::shared_ptr<Statement> stmt : *probe.stmts)
+  {
     stmt->accept(*this);
   }
 }

--- a/src/ast/field_analyser.h
+++ b/src/ast/field_analyser.h
@@ -11,7 +11,7 @@ namespace ast {
 
 class FieldAnalyser : public Visitor {
 public:
-  explicit FieldAnalyser(Node *root,
+  explicit FieldAnalyser(std::shared_ptr<Node> root,
                          BPFtrace &bpftrace,
                          std::ostream &out = std::cerr)
       : type_(""),
@@ -58,7 +58,7 @@ private:
                     const std::map<std::string, SizedType>& args2);
 
   std::string    type_;
-  Node          *root_;
+  std::shared_ptr<Node> root_;
   BPFtrace      &bpftrace_;
   bpf_prog_type  prog_type_;
   bool           has_builtin_args_;

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -606,14 +606,15 @@ Value *IRBuilderBPF::CreateUSDTReadArgument(Value *ctx,
   return result;
 }
 
-Value *IRBuilderBPF::CreateUSDTReadArgument(Value *ctx,
-                                            std::shared_ptr<AttachPoint> attach_point,
-                                            int usdt_location_index,
-                                            int arg_num,
-                                            Builtin &builtin,
-                                            pid_t pid,
-                                            AddrSpace as,
-                                            const location &loc)
+Value *IRBuilderBPF::CreateUSDTReadArgument(
+    Value *ctx,
+    std::shared_ptr<AttachPoint> attach_point,
+    int usdt_location_index,
+    int arg_num,
+    Builtin &builtin,
+    pid_t pid,
+    AddrSpace as,
+    const location &loc)
 {
   assert(ctx && ctx->getType() == getInt8PtrTy());
   struct bcc_usdt_argument argument;

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -607,7 +607,7 @@ Value *IRBuilderBPF::CreateUSDTReadArgument(Value *ctx,
 }
 
 Value *IRBuilderBPF::CreateUSDTReadArgument(Value *ctx,
-                                            AttachPoint *attach_point,
+                                            std::shared_ptr<AttachPoint> attach_point,
                                             int usdt_location_index,
                                             int arg_num,
                                             Builtin &builtin,

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -105,7 +105,7 @@ public:
                                AddrSpace as,
                                const location &loc);
   Value *CreateUSDTReadArgument(Value *ctx,
-                                AttachPoint *attach_point,
+                                std::shared_ptr<AttachPoint> attach_point,
                                 int usdt_location_index,
                                 int arg_name,
                                 Builtin &builtin,

--- a/src/ast/printer.cpp
+++ b/src/ast/printer.cpp
@@ -106,7 +106,7 @@ void Printer::visit(Call &call)
 
   ++depth_;
   if (call.vargs) {
-    for (Expression *expr : *call.vargs) {
+    for (std::shared_ptr<Expression> expr : *call.vargs) {
       expr->accept(*this);
     }
   }
@@ -120,7 +120,7 @@ void Printer::visit(Map &map)
 
   ++depth_;
   if (map.vargs) {
-    for (Expression *expr : *map.vargs) {
+    for (std::shared_ptr<Expression> expr : *map.vargs) {
       expr->accept(*this);
     }
   }
@@ -222,7 +222,7 @@ void Printer::visit(Tuple &tuple)
   out_ << indent << "tuple:" << std::endl;
 
   ++depth_;
-  for (Expression *expr : *tuple.elems)
+  for (std::shared_ptr<Expression> expr : *tuple.elems)
     expr->accept(*this);
   --depth_;
 }
@@ -266,13 +266,13 @@ void Printer::visit(If &if_block)
   ++depth_;
   out_ << indent << " then" << std::endl;
 
-  for (Statement *stmt : *if_block.stmts) {
+  for (std::shared_ptr<Statement> stmt : *if_block.stmts) {
     stmt->accept(*this);
   }
 
   if (if_block.else_stmts) {
     out_ << indent << " else" << std::endl;
-    for (Statement *stmt : *if_block.else_stmts) {
+    for (std::shared_ptr<Statement> stmt : *if_block.else_stmts) {
       stmt->accept(*this);
     }
   }
@@ -289,7 +289,7 @@ void Printer::visit(Unroll &unroll)
   out_ << indent << " block" << std::endl;
 
   ++depth_;
-  for (Statement *stmt : *unroll.stmts) {
+  for (std::shared_ptr<Statement> stmt : *unroll.stmts) {
     stmt->accept(*this);
   }
   depth_ -= 2;
@@ -307,7 +307,7 @@ void Printer::visit(While &while_block)
   ++depth_;
   out_ << indent << " )" << std::endl;
 
-  for (Statement *stmt : *while_block.stmts)
+  for (std::shared_ptr<Statement> stmt : *while_block.stmts)
   {
     stmt->accept(*this);
   }
@@ -337,7 +337,7 @@ void Printer::visit(AttachPoint &ap)
 
 void Printer::visit(Probe &probe)
 {
-  for (AttachPoint *ap : *probe.attach_points) {
+  for (std::shared_ptr<AttachPoint> ap : *probe.attach_points) {
     ap->accept(*this);
   }
 
@@ -345,7 +345,7 @@ void Printer::visit(Probe &probe)
   if (probe.pred) {
     probe.pred->accept(*this);
   }
-  for (Statement *stmt : *probe.stmts) {
+  for (std::shared_ptr<Statement> stmt : *probe.stmts) {
     stmt->accept(*this);
   }
   --depth_;
@@ -360,7 +360,7 @@ void Printer::visit(Program &program)
   out_ << indent << "Program" << std::endl;
 
   ++depth_;
-  for (Probe *probe : *program.probes)
+  for (std::shared_ptr<Probe> probe : *program.probes)
     probe->accept(*this);
   --depth_;
 }

--- a/src/ast/printer.cpp
+++ b/src/ast/printer.cpp
@@ -106,7 +106,8 @@ void Printer::visit(Call &call)
 
   ++depth_;
   if (call.vargs) {
-    for (std::shared_ptr<Expression> expr : *call.vargs) {
+    for (std::shared_ptr<Expression> expr : *call.vargs)
+    {
       expr->accept(*this);
     }
   }
@@ -120,7 +121,8 @@ void Printer::visit(Map &map)
 
   ++depth_;
   if (map.vargs) {
-    for (std::shared_ptr<Expression> expr : *map.vargs) {
+    for (std::shared_ptr<Expression> expr : *map.vargs)
+    {
       expr->accept(*this);
     }
   }
@@ -266,13 +268,15 @@ void Printer::visit(If &if_block)
   ++depth_;
   out_ << indent << " then" << std::endl;
 
-  for (std::shared_ptr<Statement> stmt : *if_block.stmts) {
+  for (std::shared_ptr<Statement> stmt : *if_block.stmts)
+  {
     stmt->accept(*this);
   }
 
   if (if_block.else_stmts) {
     out_ << indent << " else" << std::endl;
-    for (std::shared_ptr<Statement> stmt : *if_block.else_stmts) {
+    for (std::shared_ptr<Statement> stmt : *if_block.else_stmts)
+    {
       stmt->accept(*this);
     }
   }
@@ -289,7 +293,8 @@ void Printer::visit(Unroll &unroll)
   out_ << indent << " block" << std::endl;
 
   ++depth_;
-  for (std::shared_ptr<Statement> stmt : *unroll.stmts) {
+  for (std::shared_ptr<Statement> stmt : *unroll.stmts)
+  {
     stmt->accept(*this);
   }
   depth_ -= 2;
@@ -337,7 +342,8 @@ void Printer::visit(AttachPoint &ap)
 
 void Printer::visit(Probe &probe)
 {
-  for (std::shared_ptr<AttachPoint> ap : *probe.attach_points) {
+  for (std::shared_ptr<AttachPoint> ap : *probe.attach_points)
+  {
     ap->accept(*this);
   }
 
@@ -345,7 +351,8 @@ void Printer::visit(Probe &probe)
   if (probe.pred) {
     probe.pred->accept(*this);
   }
-  for (std::shared_ptr<Statement> stmt : *probe.stmts) {
+  for (std::shared_ptr<Statement> stmt : *probe.stmts)
+  {
     stmt->accept(*this);
   }
   --depth_;

--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -124,8 +124,9 @@ void SemanticAnalyser::visit(Identifier &identifier)
   }
 }
 
-void SemanticAnalyser::builtin_args_tracepoint(std::shared_ptr<AttachPoint> attach_point,
-                                               Builtin &builtin)
+void SemanticAnalyser::builtin_args_tracepoint(
+    std::shared_ptr<AttachPoint> attach_point,
+    Builtin &builtin)
 {
   /*
    * tracepoint wildcard expansion, part 2 of 3. This:
@@ -450,7 +451,8 @@ void SemanticAnalyser::visit(Call &call)
   func_setter scope_bound_func_setter{ *this, call.func };
 
   if (call.vargs) {
-    for (std::shared_ptr<Expression> expr : *call.vargs) {
+    for (std::shared_ptr<Expression> expr : *call.vargs)
+    {
       expr->accept(*this);
     }
   }
@@ -592,8 +594,9 @@ void SemanticAnalyser::visit(Call &call)
         else
         {
           auto binop = std::dynamic_pointer_cast<Binop>(arg);
-          if (!(binop && (std::dynamic_pointer_cast<PositionalParameter>(binop->left) ||
-                          std::dynamic_pointer_cast<PositionalParameter>(binop->right))))
+          if (!(binop &&
+                (std::dynamic_pointer_cast<PositionalParameter>(binop->left) ||
+                 std::dynamic_pointer_cast<PositionalParameter>(binop->right))))
           {
             // Only str($1), str($1 + CONST), or str(CONST + $1) are allowed
             LOG(ERROR, call.loc, err_)
@@ -1252,7 +1255,9 @@ void SemanticAnalyser::visit(Map &map)
       if (expr->type.IsIntTy() && expr->type.size < 8)
       {
         std::string type = expr->type.IsSigned() ? "int64" : "uint64";
-        std::shared_ptr<Expression> cast = std::make_shared<ast::Cast>(type, false, expr);
+        std::shared_ptr<Expression> cast = std::make_shared<ast::Cast>(type,
+                                                                       false,
+                                                                       expr);
         cast->accept(*this);
         map.vargs->at(i) = cast;
         expr = cast;
@@ -1349,7 +1354,8 @@ void SemanticAnalyser::visit(ArrayAccess &arr)
 
     if (indextype.IsIntTy() && arr.indexpr->is_literal)
     {
-      std::shared_ptr<Integer> index = std::static_pointer_cast<Integer>(arr.indexpr);
+      std::shared_ptr<Integer> index = std::static_pointer_cast<Integer>(
+          arr.indexpr);
 
       if ((size_t) index->n >= type.size)
         LOG(ERROR, arr.loc, err_)
@@ -1656,7 +1662,8 @@ void SemanticAnalyser::visit(Unroll &unroll)
   {
     unroll.var = integer->n;
   }
-  else if (auto param = std::dynamic_pointer_cast<PositionalParameter>(unroll.expr))
+  else if (auto param = std::dynamic_pointer_cast<PositionalParameter>(
+               unroll.expr))
   {
     if (param->ptype == PositionalParameterType::count)
     {
@@ -2401,16 +2408,17 @@ void SemanticAnalyser::visit(Probe &probe)
   variable_val_.clear();
   probe_ = &probe;
 
-  for (std::shared_ptr<AttachPoint> ap : *probe.attach_points) {
+  for (std::shared_ptr<AttachPoint> ap : *probe.attach_points)
+  {
     ap->accept(*this);
   }
   if (probe.pred) {
     probe.pred->accept(*this);
   }
-  for (std::shared_ptr<Statement> stmt : *probe.stmts) {
+  for (std::shared_ptr<Statement> stmt : *probe.stmts)
+  {
     stmt->accept(*this);
   }
-
 }
 
 void SemanticAnalyser::visit(Program &program)

--- a/src/ast/semantic_analyser.h
+++ b/src/ast/semantic_analyser.h
@@ -19,14 +19,13 @@ public:
                             BPFtrace &bpftrace,
                             std::ostream &out = std::cerr,
                             bool has_child = true)
-      : root_(root),
-        bpftrace_(bpftrace),
-        out_(out),
-        has_child_(has_child)
+      : root_(root), bpftrace_(bpftrace), out_(out), has_child_(has_child)
   {
   }
 
-  explicit SemanticAnalyser(std::shared_ptr<Node> root, BPFtrace &bpftrace, bool has_child)
+  explicit SemanticAnalyser(std::shared_ptr<Node> root,
+                            BPFtrace &bpftrace,
+                            bool has_child)
       : SemanticAnalyser(root, bpftrace, std::cerr, has_child)
   {
   }
@@ -86,7 +85,8 @@ private:
 
   void assign_map_type(const Map &map, const SizedType &type);
 
-  void builtin_args_tracepoint(std::shared_ptr<AttachPoint> attach_point, Builtin &builtin);
+  void builtin_args_tracepoint(std::shared_ptr<AttachPoint> attach_point,
+                               Builtin &builtin);
   ProbeType single_provider_type(void);
   template <typename T>
   int create_maps_impl(void);

--- a/src/ast/semantic_analyser.h
+++ b/src/ast/semantic_analyser.h
@@ -15,7 +15,7 @@ namespace ast {
 
 class SemanticAnalyser : public Visitor {
 public:
-  explicit SemanticAnalyser(Node *root,
+  explicit SemanticAnalyser(std::shared_ptr<Node> root,
                             BPFtrace &bpftrace,
                             std::ostream &out = std::cerr,
                             bool has_child = true)
@@ -26,7 +26,7 @@ public:
   {
   }
 
-  explicit SemanticAnalyser(Node *root, BPFtrace &bpftrace, bool has_child)
+  explicit SemanticAnalyser(std::shared_ptr<Node> root, BPFtrace &bpftrace, bool has_child)
       : SemanticAnalyser(root, bpftrace, std::cerr, has_child)
   {
   }
@@ -63,7 +63,7 @@ public:
   int analyse();
 
 private:
-  Node *root_;
+  std::shared_ptr<Node> root_;
   BPFtrace &bpftrace_;
   std::ostream &out_;
   std::ostringstream err_;
@@ -86,7 +86,7 @@ private:
 
   void assign_map_type(const Map &map, const SizedType &type);
 
-  void builtin_args_tracepoint(AttachPoint *attach_point, Builtin &builtin);
+  void builtin_args_tracepoint(std::shared_ptr<AttachPoint> attach_point, Builtin &builtin);
   ProbeType single_provider_type(void);
   template <typename T>
   int create_maps_impl(void);
@@ -96,7 +96,7 @@ private:
   {
     return loop_depth_ > 0;
   };
-  void accept_statements(StatementList *stmts);
+  void accept_statements(std::shared_ptr<StatementList> stmts);
 
   Probe *probe_;
   std::string func_;

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -2188,8 +2188,9 @@ std::string BPFtrace::get_string_literal(const ast::Expression *expr) const
       // Positional parameters in the form str($1) can be used as literals
       if (str_call->func == "str")
       {
-        if (auto pos_param = std::dynamic_pointer_cast<const ast::PositionalParameter>(
-                str_call->vargs->at(0)))
+        if (auto pos_param =
+                std::dynamic_pointer_cast<const ast::PositionalParameter>(
+                    str_call->vargs->at(0)))
           return get_param(pos_param->n, true);
       }
     }
@@ -2199,7 +2200,9 @@ std::string BPFtrace::get_string_literal(const ast::Expression *expr) const
   return "";
 }
 
-std::string BPFtrace::get_string_literal(const std::shared_ptr<ast::Expression> expr) const {
+std::string BPFtrace::get_string_literal(
+    const std::shared_ptr<ast::Expression> expr) const
+{
   // Just calls the raw pointer overload.
   // TODO: Can the raw pointer overload just be removed instead?
   return this->get_string_literal(expr.get());

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -2188,7 +2188,7 @@ std::string BPFtrace::get_string_literal(const ast::Expression *expr) const
       // Positional parameters in the form str($1) can be used as literals
       if (str_call->func == "str")
       {
-        if (auto *pos_param = dynamic_cast<const ast::PositionalParameter *>(
+        if (auto pos_param = std::dynamic_pointer_cast<const ast::PositionalParameter>(
                 str_call->vargs->at(0)))
           return get_param(pos_param->n, true);
       }
@@ -2199,4 +2199,9 @@ std::string BPFtrace::get_string_literal(const ast::Expression *expr) const
   return "";
 }
 
+std::string BPFtrace::get_string_literal(const std::shared_ptr<ast::Expression> expr) const {
+  // Just calls the raw pointer overload.
+  // TODO: Can the raw pointer overload just be removed instead?
+  return this->get_string_literal(expr.get());
+}
 } // namespace bpftrace

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -132,6 +132,7 @@ public:
   void request_finalize();
   bool is_aslr_enabled(int pid);
   std::string get_string_literal(const ast::Expression *expr) const;
+  std::string get_string_literal(const std::shared_ptr<ast::Expression> expr) const;
 
   std::string cmd_;
   bool finalize_ = false;

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -132,7 +132,8 @@ public:
   void request_finalize();
   bool is_aslr_enabled(int pid);
   std::string get_string_literal(const ast::Expression *expr) const;
-  std::string get_string_literal(const std::shared_ptr<ast::Expression> expr) const;
+  std::string get_string_literal(
+      const std::shared_ptr<ast::Expression> expr) const;
 
   std::string cmd_;
   bool finalize_ = false;

--- a/src/clang_parser.cpp
+++ b/src/clang_parser.cpp
@@ -616,7 +616,7 @@ std::unordered_set<std::string> ClangParser::get_incomplete_types(
   return type_data.incomplete_types;
 }
 
-bool ClangParser::parse(ast::Program *program, BPFtrace &bpftrace, std::vector<std::string> extra_flags)
+bool ClangParser::parse(std::shared_ptr<ast::Program> program, BPFtrace &bpftrace, std::vector<std::string> extra_flags)
 {
   auto input = "#include <__btf_generated_header.h>\n" + program->c_definitions;
 

--- a/src/clang_parser.cpp
+++ b/src/clang_parser.cpp
@@ -616,7 +616,9 @@ std::unordered_set<std::string> ClangParser::get_incomplete_types(
   return type_data.incomplete_types;
 }
 
-bool ClangParser::parse(std::shared_ptr<ast::Program> program, BPFtrace &bpftrace, std::vector<std::string> extra_flags)
+bool ClangParser::parse(std::shared_ptr<ast::Program> program,
+                        BPFtrace &bpftrace,
+                        std::vector<std::string> extra_flags)
 {
   auto input = "#include <__btf_generated_header.h>\n" + program->c_definitions;
 

--- a/src/clang_parser.h
+++ b/src/clang_parser.h
@@ -16,7 +16,7 @@ class Program;
 class ClangParser
 {
 public:
-  bool parse(ast::Program *program,
+  bool parse(std::shared_ptr<ast::Program> program,
              BPFtrace &bpftrace,
              std::vector<std::string> extra_flags = {});
 

--- a/src/driver.h
+++ b/src/driver.h
@@ -25,7 +25,7 @@ public:
   void error(std::ostream &, const location &, const std::string &);
   void error(const location &l, const std::string &m);
   void error(const std::string &m);
-  ast::Program *root_{ nullptr };
+  std::shared_ptr<ast::Program> root_;
 
   BPFtrace &bpftrace_;
 

--- a/src/tracepoint_format_parser.cpp
+++ b/src/tracepoint_format_parser.cpp
@@ -13,7 +13,8 @@ namespace bpftrace {
 
 std::set<std::string> TracepointFormatParser::struct_list;
 
-bool TracepointFormatParser::parse(std::shared_ptr<ast::Program> program, BPFtrace &bpftrace)
+bool TracepointFormatParser::parse(std::shared_ptr<ast::Program> program,
+                                   BPFtrace &bpftrace)
 {
   std::vector<std::shared_ptr<ast::Probe>> probes_with_tracepoint;
   for (std::shared_ptr<ast::Probe> probe : *program->probes)

--- a/src/tracepoint_format_parser.cpp
+++ b/src/tracepoint_format_parser.cpp
@@ -13,11 +13,11 @@ namespace bpftrace {
 
 std::set<std::string> TracepointFormatParser::struct_list;
 
-bool TracepointFormatParser::parse(ast::Program *program, BPFtrace &bpftrace)
+bool TracepointFormatParser::parse(std::shared_ptr<ast::Program> program, BPFtrace &bpftrace)
 {
-  std::vector<ast::Probe*> probes_with_tracepoint;
-  for (ast::Probe *probe : *program->probes)
-    for (ast::AttachPoint *ap : *probe->attach_points)
+  std::vector<std::shared_ptr<ast::Probe>> probes_with_tracepoint;
+  for (std::shared_ptr<ast::Probe> probe : *program->probes)
+    for (std::shared_ptr<ast::AttachPoint> ap : *probe->attach_points)
       if (ap->provider == "tracepoint") {
         probes_with_tracepoint.push_back(probe);
         continue;
@@ -29,11 +29,11 @@ bool TracepointFormatParser::parse(ast::Program *program, BPFtrace &bpftrace)
   ast::TracepointArgsVisitor n{};
   if (!bpftrace.btf_.has_data())
     program->c_definitions += "#include <linux/types.h>\n";
-  for (ast::Probe *probe : probes_with_tracepoint)
+  for (std::shared_ptr<ast::Probe> probe : probes_with_tracepoint)
   {
     n.analyse(probe);
 
-    for (ast::AttachPoint *ap : *probe->attach_points)
+    for (std::shared_ptr<ast::AttachPoint> ap : *probe->attach_points)
     {
       if (ap->provider == "tracepoint")
       {

--- a/src/tracepoint_format_parser.h
+++ b/src/tracepoint_format_parser.h
@@ -26,14 +26,16 @@ public:
   };  // Leaf
   void visit(Call &call) override {
     if (call.vargs) {
-      for (std::shared_ptr<Expression> expr : *call.vargs) {
+      for (std::shared_ptr<Expression> expr : *call.vargs)
+      {
         expr->accept(*this);
       }
     }
   };
   void visit(Map &map) override {
     if (map.vargs) {
-      for (std::shared_ptr<Expression> expr : *map.vargs) {
+      for (std::shared_ptr<Expression> expr : *map.vargs)
+      {
         expr->accept(*this);
       }
     }
@@ -78,18 +80,21 @@ public:
   void visit(If &if_block) override {
     if_block.cond->accept(*this);
 
-    for (std::shared_ptr<Statement> stmt : *if_block.stmts) {
+    for (std::shared_ptr<Statement> stmt : *if_block.stmts)
+    {
       stmt->accept(*this);
     }
 
     if (if_block.else_stmts) {
-      for (std::shared_ptr<Statement> stmt : *if_block.else_stmts) {
+      for (std::shared_ptr<Statement> stmt : *if_block.else_stmts)
+      {
         stmt->accept(*this);
       }
     }
   };
   void visit(Unroll &unroll) override {
-    for (std::shared_ptr<Statement> stmt : *unroll.stmts) {
+    for (std::shared_ptr<Statement> stmt : *unroll.stmts)
+    {
       stmt->accept(*this);
     }
   };
@@ -108,13 +113,15 @@ public:
   void visit(__attribute__((unused)) AttachPoint &ap) override { };  // Leaf
   void visit(Probe &probe) override {
     probe_ = &probe;
-    for (std::shared_ptr<AttachPoint> ap : *probe.attach_points) {
+    for (std::shared_ptr<AttachPoint> ap : *probe.attach_points)
+    {
       ap->accept(*this);
     }
     if (probe.pred) {
       probe.pred->accept(*this);
     }
-    for (std::shared_ptr<Statement> stmt : *probe.stmts) {
+    for (std::shared_ptr<Statement> stmt : *probe.stmts)
+    {
       stmt->accept(*this);
     }
   };
@@ -123,12 +130,14 @@ public:
       probe->accept(*this);
   };
 
-  void analyse(std::shared_ptr<Probe> probe) {
+  void analyse(std::shared_ptr<Probe> probe)
+  {
     probe_ = probe.get();
     probe->accept(*this);
   }
+
 private:
-  Probe* probe_;
+  Probe *probe_;
 };
 } // namespace ast
 

--- a/src/tracepoint_format_parser.h
+++ b/src/tracepoint_format_parser.h
@@ -26,14 +26,14 @@ public:
   };  // Leaf
   void visit(Call &call) override {
     if (call.vargs) {
-      for (Expression *expr : *call.vargs) {
+      for (std::shared_ptr<Expression> expr : *call.vargs) {
         expr->accept(*this);
       }
     }
   };
   void visit(Map &map) override {
     if (map.vargs) {
-      for (Expression *expr : *map.vargs) {
+      for (std::shared_ptr<Expression> expr : *map.vargs) {
         expr->accept(*this);
       }
     }
@@ -62,7 +62,7 @@ public:
   };
   void visit(Tuple &tuple) override
   {
-    for (Expression *expr : *tuple.elems)
+    for (std::shared_ptr<Expression> expr : *tuple.elems)
       expr->accept(*this);
   };
   void visit(ExprStatement &expr) override {
@@ -78,18 +78,18 @@ public:
   void visit(If &if_block) override {
     if_block.cond->accept(*this);
 
-    for (Statement *stmt : *if_block.stmts) {
+    for (std::shared_ptr<Statement> stmt : *if_block.stmts) {
       stmt->accept(*this);
     }
 
     if (if_block.else_stmts) {
-      for (Statement *stmt : *if_block.else_stmts) {
+      for (std::shared_ptr<Statement> stmt : *if_block.else_stmts) {
         stmt->accept(*this);
       }
     }
   };
   void visit(Unroll &unroll) override {
-    for (Statement *stmt : *unroll.stmts) {
+    for (std::shared_ptr<Statement> stmt : *unroll.stmts) {
       stmt->accept(*this);
     }
   };
@@ -97,7 +97,7 @@ public:
   {
     while_block.cond->accept(*this);
 
-    for (Statement *stmt : *while_block.stmts)
+    for (std::shared_ptr<Statement> stmt : *while_block.stmts)
     {
       stmt->accept(*this);
     }
@@ -108,34 +108,34 @@ public:
   void visit(__attribute__((unused)) AttachPoint &ap) override { };  // Leaf
   void visit(Probe &probe) override {
     probe_ = &probe;
-    for (AttachPoint *ap : *probe.attach_points) {
+    for (std::shared_ptr<AttachPoint> ap : *probe.attach_points) {
       ap->accept(*this);
     }
     if (probe.pred) {
       probe.pred->accept(*this);
     }
-    for (Statement *stmt : *probe.stmts) {
+    for (std::shared_ptr<Statement> stmt : *probe.stmts) {
       stmt->accept(*this);
     }
   };
   void visit(Program &program) override {
-    for (Probe *probe : *program.probes)
+    for (std::shared_ptr<Probe> probe : *program.probes)
       probe->accept(*this);
   };
 
-  void analyse(Probe *probe) {
-    probe_ = probe;
+  void analyse(std::shared_ptr<Probe> probe) {
+    probe_ = probe.get();
     probe->accept(*this);
   }
 private:
-  Probe *probe_;
+  Probe* probe_;
 };
 } // namespace ast
 
 class TracepointFormatParser
 {
 public:
-  static bool parse(ast::Program *program, BPFtrace &bpftrace);
+  static bool parse(std::shared_ptr<ast::Program> program, BPFtrace &bpftrace);
   static std::string get_struct_name(const std::string &category,
                                      const std::string &event_name);
   static std::string get_struct_name(const std::string &probe_id);

--- a/tests/ast.cpp
+++ b/tests/ast.cpp
@@ -11,9 +11,12 @@ using bpftrace::ast::Probe;
 
 namespace {
 /* Convenience function to help generate attach point lists for testing */
-template <typename ...Args>
-std::shared_ptr<AttachPointList> make_attach_point_list(Args... args) {
-  const std::vector<std::shared_ptr<AttachPoint>> list = {std::make_shared<AttachPoint>(args)...};
+template <typename... Args>
+std::shared_ptr<AttachPointList> make_attach_point_list(Args... args)
+{
+  const std::vector<std::shared_ptr<AttachPoint>> list = {
+    std::make_shared<AttachPoint>(args)...
+  };
   return std::make_shared<AttachPointList>(list);
 }
 } // Anonymous namespace
@@ -65,7 +68,7 @@ TEST(ast, probe_name_uprobe)
   ap1.provider = "uprobe";
   ap1.target = "/bin/sh";
   ap1.func = "readline";
-  auto attach_points1 = make_attach_point_list( ap1 );
+  auto attach_points1 = make_attach_point_list(ap1);
   Probe uprobe1(attach_points1, nullptr, nullptr);
   EXPECT_EQ(uprobe1.name(), "uprobe:/bin/sh:readline");
 
@@ -73,7 +76,7 @@ TEST(ast, probe_name_uprobe)
   ap2.provider = "uprobe";
   ap2.target = "/bin/sh";
   ap2.func = "somefunc";
-  auto attach_points2 = make_attach_point_list( ap1, ap2 );
+  auto attach_points2 = make_attach_point_list(ap1, ap2);
   Probe uprobe2(attach_points2, nullptr, nullptr);
   EXPECT_EQ(uprobe2.name(), "uprobe:/bin/sh:readline,uprobe:/bin/sh:somefunc");
 
@@ -81,7 +84,7 @@ TEST(ast, probe_name_uprobe)
   ap3.provider = "uprobe";
   ap3.target = "/bin/sh";
   ap3.address = 1000;
-  auto attach_points3 = make_attach_point_list( ap1, ap2, ap3 );
+  auto attach_points3 = make_attach_point_list(ap1, ap2, ap3);
   Probe uprobe3(attach_points3, nullptr, nullptr);
   EXPECT_EQ(uprobe3.name(), "uprobe:/bin/sh:readline,uprobe:/bin/sh:somefunc,uprobe:/bin/sh:1000");
 
@@ -90,7 +93,7 @@ TEST(ast, probe_name_uprobe)
   ap4.target = "/bin/sh";
   ap4.func = "somefunc";
   ap4.func_offset = 10;
-  auto attach_points4 = make_attach_point_list( ap1, ap2, ap3, ap4 );
+  auto attach_points4 = make_attach_point_list(ap1, ap2, ap3, ap4);
   Probe uprobe4(attach_points4, nullptr, nullptr);
   EXPECT_EQ(uprobe4.name(), "uprobe:/bin/sh:readline,uprobe:/bin/sh:somefunc,uprobe:/bin/sh:1000,uprobe:/bin/sh:somefunc+10");
 
@@ -98,7 +101,7 @@ TEST(ast, probe_name_uprobe)
   ap5.provider = "uprobe";
   ap5.target = "/bin/sh";
   ap5.address = 10;
-  auto attach_points5 = make_attach_point_list( ap5 );
+  auto attach_points5 = make_attach_point_list(ap5);
   Probe uprobe5(attach_points5, nullptr, nullptr);
   EXPECT_EQ(uprobe5.name(), "uprobe:/bin/sh:10");
 
@@ -106,7 +109,7 @@ TEST(ast, probe_name_uprobe)
   ap6.provider = "uretprobe";
   ap6.target = "/bin/sh";
   ap6.address = 10;
-  auto attach_points6 = make_attach_point_list( ap6 );
+  auto attach_points6 = make_attach_point_list(ap6);
   Probe uprobe6(attach_points6, nullptr, nullptr);
   EXPECT_EQ(uprobe6.name(), "uretprobe:/bin/sh:10");
 }
@@ -117,7 +120,7 @@ TEST(ast, probe_name_usdt)
   ap1.provider = "usdt";
   ap1.target = "/bin/sh";
   ap1.func = "probe1";
-  auto attach_points1 = make_attach_point_list( ap1 );
+  auto attach_points1 = make_attach_point_list(ap1);
   Probe usdt1(attach_points1, nullptr, nullptr);
   EXPECT_EQ(usdt1.name(), "usdt:/bin/sh:probe1");
 
@@ -125,7 +128,7 @@ TEST(ast, probe_name_usdt)
   ap2.provider = "usdt";
   ap2.target = "/bin/sh";
   ap2.func = "probe2";
-  auto attach_points2 = make_attach_point_list( ap1, ap2 );
+  auto attach_points2 = make_attach_point_list(ap1, ap2);
   Probe usdt2(attach_points2, nullptr, nullptr);
   EXPECT_EQ(usdt2.name(), "usdt:/bin/sh:probe1,usdt:/bin/sh:probe2");
 }
@@ -142,7 +145,7 @@ TEST(ast, attach_point_name)
   ap3.provider = "uprobe";
   ap3.target = "/bin/sh";
   ap3.func = "readline";
-  auto attach_points = make_attach_point_list( ap1, ap2, ap3 );
+  auto attach_points = make_attach_point_list(ap1, ap2, ap3);
   Probe kprobe(attach_points, nullptr, nullptr);
   EXPECT_EQ(ap2.name("sys_thisone"), "kprobe:sys_thisone");
 

--- a/tests/ast.cpp
+++ b/tests/ast.cpp
@@ -9,18 +9,27 @@ using bpftrace::ast::AttachPoint;
 using bpftrace::ast::AttachPointList;
 using bpftrace::ast::Probe;
 
+namespace {
+/* Convenience function to help generate attach point lists for testing */
+template <typename ...Args>
+std::shared_ptr<AttachPointList> make_attach_point_list(Args... args) {
+  const std::vector<std::shared_ptr<AttachPoint>> list = {std::make_shared<AttachPoint>(args)...};
+  return std::make_shared<AttachPointList>(list);
+}
+} // Anonymous namespace
+
 TEST(ast, probe_name_special)
 {
   AttachPoint ap1("");
   ap1.provider = "BEGIN";
-  AttachPointList attach_points1 = { &ap1 };
-  Probe begin(&attach_points1, nullptr, nullptr);
+  auto attach_points1 = make_attach_point_list(ap1);
+  Probe begin(attach_points1, nullptr, nullptr);
   EXPECT_EQ(begin.name(), "BEGIN");
 
   AttachPoint ap2("");
   ap2.provider = "END";
-  AttachPointList attach_points2 = { &ap2 };
-  Probe end(&attach_points2, nullptr, nullptr);
+  auto attach_points2 = make_attach_point_list(ap2);
+  Probe end(attach_points2, nullptr, nullptr);
   EXPECT_EQ(end.name(), "END");
 }
 
@@ -29,23 +38,23 @@ TEST(ast, probe_name_kprobe)
   AttachPoint ap1("");
   ap1.provider = "kprobe";
   ap1.func = "sys_read";
-  AttachPointList attach_points1 = { &ap1 };
-  Probe kprobe1(&attach_points1, nullptr, nullptr);
+  auto attach_points1 = make_attach_point_list(ap1);
+  Probe kprobe1(attach_points1, nullptr, nullptr);
   EXPECT_EQ(kprobe1.name(), "kprobe:sys_read");
 
   AttachPoint ap2("");
   ap2.provider = "kprobe";
   ap2.func = "sys_write";
-  AttachPointList attach_points2 = { &ap1, &ap2 };
-  Probe kprobe2(&attach_points2, nullptr, nullptr);
+  auto attach_points2 = make_attach_point_list(ap1, ap2);
+  Probe kprobe2(attach_points2, nullptr, nullptr);
   EXPECT_EQ(kprobe2.name(), "kprobe:sys_read,kprobe:sys_write");
 
   AttachPoint ap3("");
   ap3.provider = "kprobe";
   ap3.func = "sys_read";
   ap3.func_offset = 10;
-  AttachPointList attach_points3 = { &ap1, &ap2, &ap3 };
-  Probe kprobe3(&attach_points3, nullptr, nullptr);
+  auto attach_points3 = make_attach_point_list(ap1, ap2, ap3);
+  Probe kprobe3(attach_points3, nullptr, nullptr);
   EXPECT_EQ(kprobe3.name(),
             "kprobe:sys_read,kprobe:sys_write,kprobe:sys_read+10");
 }
@@ -56,24 +65,24 @@ TEST(ast, probe_name_uprobe)
   ap1.provider = "uprobe";
   ap1.target = "/bin/sh";
   ap1.func = "readline";
-  AttachPointList attach_points1 = { &ap1 };
-  Probe uprobe1(&attach_points1, nullptr, nullptr);
+  auto attach_points1 = make_attach_point_list( ap1 );
+  Probe uprobe1(attach_points1, nullptr, nullptr);
   EXPECT_EQ(uprobe1.name(), "uprobe:/bin/sh:readline");
 
   AttachPoint ap2("");
   ap2.provider = "uprobe";
   ap2.target = "/bin/sh";
   ap2.func = "somefunc";
-  AttachPointList attach_points2 = { &ap1, &ap2 };
-  Probe uprobe2(&attach_points2, nullptr, nullptr);
+  auto attach_points2 = make_attach_point_list( ap1, ap2 );
+  Probe uprobe2(attach_points2, nullptr, nullptr);
   EXPECT_EQ(uprobe2.name(), "uprobe:/bin/sh:readline,uprobe:/bin/sh:somefunc");
 
   AttachPoint ap3("");
   ap3.provider = "uprobe";
   ap3.target = "/bin/sh";
   ap3.address = 1000;
-  AttachPointList attach_points3 = { &ap1, &ap2, &ap3 };
-  Probe uprobe3(&attach_points3, nullptr, nullptr);
+  auto attach_points3 = make_attach_point_list( ap1, ap2, ap3 );
+  Probe uprobe3(attach_points3, nullptr, nullptr);
   EXPECT_EQ(uprobe3.name(), "uprobe:/bin/sh:readline,uprobe:/bin/sh:somefunc,uprobe:/bin/sh:1000");
 
   AttachPoint ap4("");
@@ -81,24 +90,24 @@ TEST(ast, probe_name_uprobe)
   ap4.target = "/bin/sh";
   ap4.func = "somefunc";
   ap4.func_offset = 10;
-  AttachPointList attach_points4 = { &ap1, &ap2, &ap3, &ap4 };
-  Probe uprobe4(&attach_points4, nullptr, nullptr);
+  auto attach_points4 = make_attach_point_list( ap1, ap2, ap3, ap4 );
+  Probe uprobe4(attach_points4, nullptr, nullptr);
   EXPECT_EQ(uprobe4.name(), "uprobe:/bin/sh:readline,uprobe:/bin/sh:somefunc,uprobe:/bin/sh:1000,uprobe:/bin/sh:somefunc+10");
 
   AttachPoint ap5("");
   ap5.provider = "uprobe";
   ap5.target = "/bin/sh";
   ap5.address = 10;
-  AttachPointList attach_points5 = { &ap5 };
-  Probe uprobe5(&attach_points5, nullptr, nullptr);
+  auto attach_points5 = make_attach_point_list( ap5 );
+  Probe uprobe5(attach_points5, nullptr, nullptr);
   EXPECT_EQ(uprobe5.name(), "uprobe:/bin/sh:10");
 
   AttachPoint ap6("");
   ap6.provider = "uretprobe";
   ap6.target = "/bin/sh";
   ap6.address = 10;
-  AttachPointList attach_points6 = { &ap6 };
-  Probe uprobe6(&attach_points6, nullptr, nullptr);
+  auto attach_points6 = make_attach_point_list( ap6 );
+  Probe uprobe6(attach_points6, nullptr, nullptr);
   EXPECT_EQ(uprobe6.name(), "uretprobe:/bin/sh:10");
 }
 
@@ -108,16 +117,16 @@ TEST(ast, probe_name_usdt)
   ap1.provider = "usdt";
   ap1.target = "/bin/sh";
   ap1.func = "probe1";
-  AttachPointList attach_points1 = { &ap1 };
-  Probe usdt1(&attach_points1, nullptr, nullptr);
+  auto attach_points1 = make_attach_point_list( ap1 );
+  Probe usdt1(attach_points1, nullptr, nullptr);
   EXPECT_EQ(usdt1.name(), "usdt:/bin/sh:probe1");
 
   AttachPoint ap2("");
   ap2.provider = "usdt";
   ap2.target = "/bin/sh";
   ap2.func = "probe2";
-  AttachPointList attach_points2 = { &ap1, &ap2 };
-  Probe usdt2(&attach_points2, nullptr, nullptr);
+  auto attach_points2 = make_attach_point_list( ap1, ap2 );
+  Probe usdt2(attach_points2, nullptr, nullptr);
   EXPECT_EQ(usdt2.name(), "usdt:/bin/sh:probe1,usdt:/bin/sh:probe2");
 }
 
@@ -133,11 +142,11 @@ TEST(ast, attach_point_name)
   ap3.provider = "uprobe";
   ap3.target = "/bin/sh";
   ap3.func = "readline";
-  AttachPointList attach_points = { &ap1, &ap2, &ap3 };
-  Probe kprobe(&attach_points, nullptr, nullptr);
+  auto attach_points = make_attach_point_list( ap1, ap2, ap3 );
+  Probe kprobe(attach_points, nullptr, nullptr);
   EXPECT_EQ(ap2.name("sys_thisone"), "kprobe:sys_thisone");
 
-  Probe uprobe(&attach_points, nullptr, nullptr);
+  Probe uprobe(attach_points, nullptr, nullptr);
   EXPECT_EQ(ap3.name("readline"), "uprobe:/bin/sh:readline");
 }
 

--- a/tests/bpftrace.cpp
+++ b/tests/bpftrace.cpp
@@ -118,9 +118,12 @@ void check_special_probe(Probe &p, const std::string &attach_point, const std::s
 
 namespace {
 /* Convenience function to help generate attach point lists for testing */
-template <typename ...Args>
-std::shared_ptr<ast::AttachPointList> make_attach_point_list(Args... args) {
-  const std::vector<std::shared_ptr<ast::AttachPoint>> list = {std::make_shared<ast::AttachPoint>(args)...};
+template <typename... Args>
+std::shared_ptr<ast::AttachPointList> make_attach_point_list(Args... args)
+{
+  const std::vector<std::shared_ptr<ast::AttachPoint>> list = {
+    std::make_shared<ast::AttachPoint>(args)...
+  };
   return std::make_shared<ast::AttachPointList>(list);
 }
 } // Anonymous namespace
@@ -129,7 +132,7 @@ TEST(bpftrace, add_begin_probe)
 {
   ast::AttachPoint a("");
   a.provider = "BEGIN";
-  auto attach_points = make_attach_point_list( a );
+  auto attach_points = make_attach_point_list(a);
   ast::Probe probe(attach_points, nullptr, nullptr);
 
   StrictMock<MockBPFtrace> bpftrace;
@@ -144,7 +147,7 @@ TEST(bpftrace, add_end_probe)
 {
   ast::AttachPoint a("");
   a.provider = "END";
-  auto attach_points = make_attach_point_list( a );
+  auto attach_points = make_attach_point_list(a);
   ast::Probe probe(attach_points, nullptr, nullptr);
 
   StrictMock<MockBPFtrace> bpftrace;
@@ -160,7 +163,7 @@ TEST(bpftrace, add_probes_single)
   ast::AttachPoint a("");
   a.provider = "kprobe";
   a.func = "sys_read";
-  auto attach_points = make_attach_point_list( a );
+  auto attach_points = make_attach_point_list(a);
   ast::Probe probe(attach_points, nullptr, nullptr);
 
   StrictMock<MockBPFtrace> bpftrace;
@@ -179,7 +182,7 @@ TEST(bpftrace, add_probes_multiple)
   ast::AttachPoint a2("");
   a2.provider = "kprobe";
   a2.func = "sys_write";
-  auto attach_points = make_attach_point_list( a1, a2 );
+  auto attach_points = make_attach_point_list(a1, a2);
   ast::Probe probe(attach_points, nullptr, nullptr);
 
   StrictMock<MockBPFtrace> bpftrace;
@@ -204,7 +207,7 @@ TEST(bpftrace, add_probes_wildcard)
   ast::AttachPoint a3("");
   a3.provider = "kprobe";
   a3.func = "sys_write";
-  auto attach_points = make_attach_point_list( a1, a2, a3 );
+  auto attach_points = make_attach_point_list(a1, a2, a3);
   ast::Probe probe(attach_points, nullptr, nullptr);
 
   auto bpftrace = get_strict_mock_bpftrace();
@@ -236,7 +239,7 @@ TEST(bpftrace, add_probes_wildcard_no_matches)
   ast::AttachPoint a3("");
   a3.provider = "kprobe";
   a3.func = "sys_write";
-  auto attach_points = make_attach_point_list( a1, a2, a3 );
+  auto attach_points = make_attach_point_list(a1, a2, a3);
   ast::Probe probe(attach_points, nullptr, nullptr);
 
   auto bpftrace = get_strict_mock_bpftrace();
@@ -259,7 +262,7 @@ TEST(bpftrace, add_probes_kernel_module)
   ast::AttachPoint a1("");
   a1.provider = "kprobe";
   a1.func = "func_in_mod";
-  auto attach_points = make_attach_point_list( a1 );
+  auto attach_points = make_attach_point_list(a1);
   ast::Probe probe(attach_points, nullptr, nullptr);
 
   auto bpftrace = get_strict_mock_bpftrace();
@@ -277,7 +280,7 @@ TEST(bpftrace, add_probes_kernel_module_wildcard)
   a1.provider = "kprobe";
   a1.func = "func_in_mo*";
   a1.need_expansion = true;
-  auto attach_points = make_attach_point_list( a1 );
+  auto attach_points = make_attach_point_list(a1);
   ast::Probe probe(attach_points, nullptr, nullptr);
 
   auto bpftrace = get_strict_mock_bpftrace();
@@ -301,7 +304,7 @@ TEST(bpftrace, add_probes_offset)
   a.provider = "kprobe";
   a.func = "sys_read";
   a.func_offset = offset;
-  auto attach_points = make_attach_point_list( a );
+  auto attach_points = make_attach_point_list(a);
   ast::Probe probe(attach_points, nullptr, nullptr);
 
   StrictMock<MockBPFtrace> bpftrace;
@@ -320,7 +323,7 @@ TEST(bpftrace, add_probes_uprobe)
   a.provider = "uprobe";
   a.target = "/bin/sh";
   a.func = "foo";
-  auto attach_points = make_attach_point_list( a );
+  auto attach_points = make_attach_point_list(a);
   ast::Probe probe(attach_points, nullptr, nullptr);
 
   StrictMock<MockBPFtrace> bpftrace;
@@ -338,7 +341,7 @@ TEST(bpftrace, add_probes_uprobe_wildcard)
   a.target = "/bin/sh";
   a.func = "*open";
   a.need_expansion = true;
-  auto attach_points = make_attach_point_list( a );
+  auto attach_points = make_attach_point_list(a);
   ast::Probe probe(attach_points, nullptr, nullptr);
 
   auto bpftrace = get_strict_mock_bpftrace();
@@ -360,7 +363,7 @@ TEST(bpftrace, add_probes_uprobe_wildcard_file)
   a.target = "/bin/*sh";
   a.func = "first_open";
   a.need_expansion = true;
-  auto attach_points = make_attach_point_list( a );
+  auto attach_points = make_attach_point_list(a);
   ast::Probe probe(attach_points, nullptr, nullptr);
 
   auto bpftrace = get_strict_mock_bpftrace();
@@ -384,7 +387,7 @@ TEST(bpftrace, add_probes_uprobe_wildcard_no_matches)
   a.target = "/bin/sh";
   a.func = "foo*";
   a.need_expansion = true;
-  auto attach_points = make_attach_point_list( a );
+  auto attach_points = make_attach_point_list(a);
   ast::Probe probe(attach_points, nullptr, nullptr);
 
   auto bpftrace = get_strict_mock_bpftrace();
@@ -401,7 +404,7 @@ TEST(bpftrace, add_probes_uprobe_string_literal)
   a.provider = "uprobe";
   a.target = "/bin/sh";
   a.func = "foo*";
-  auto attach_points = make_attach_point_list( a );
+  auto attach_points = make_attach_point_list(a);
   ast::Probe probe(attach_points, nullptr, nullptr);
 
   StrictMock<MockBPFtrace> bpftrace;
@@ -418,7 +421,7 @@ TEST(bpftrace, add_probes_uprobe_address)
   a.provider = "uprobe";
   a.target = "/bin/sh";
   a.address = 1024;
-  auto attach_points = make_attach_point_list( a );
+  auto attach_points = make_attach_point_list(a);
   ast::Probe probe(attach_points, nullptr, nullptr);
 
   StrictMock<MockBPFtrace> bpftrace;
@@ -436,7 +439,7 @@ TEST(bpftrace, add_probes_uprobe_string_offset)
   a.target = "/bin/sh";
   a.func = "foo";
   a.func_offset = 10;
-  auto attach_points = make_attach_point_list( a );
+  auto attach_points = make_attach_point_list(a);
   ast::Probe probe(attach_points, nullptr, nullptr);
 
   StrictMock<MockBPFtrace> bpftrace;
@@ -456,7 +459,7 @@ TEST(bpftrace, add_probes_uprobe_cpp_symbol)
     a.target = "/bin/sh";
     a.func = "cpp_mangled";
     a.need_expansion = true;
-    auto attach_points = make_attach_point_list( a );
+    auto attach_points = make_attach_point_list(a);
     ast::Probe probe(attach_points, nullptr, nullptr);
 
     auto bpftrace = get_strict_mock_bpftrace();
@@ -480,7 +483,7 @@ TEST(bpftrace, add_probes_uprobe_cpp_symbol_full)
   a.target = "/bin/sh";
   a.func = "cpp_mangled(int)";
   a.need_expansion = true;
-  auto attach_points = make_attach_point_list( a );
+  auto attach_points = make_attach_point_list(a);
   ast::Probe probe(attach_points, nullptr, nullptr);
 
   auto bpftrace = get_strict_mock_bpftrace();
@@ -502,7 +505,7 @@ TEST(bpftrace, add_probes_uprobe_cpp_symbol_wildcard)
   a.target = "/bin/sh";
   a.func = "cpp_man*";
   a.need_expansion = true;
-  auto attach_points = make_attach_point_list( a );
+  auto attach_points = make_attach_point_list(a);
   ast::Probe probe(attach_points, nullptr, nullptr);
 
   auto bpftrace = get_strict_mock_bpftrace();
@@ -529,7 +532,7 @@ TEST(bpftrace, add_probes_usdt)
   a.ns = "prov1";
   a.func = "mytp";
   a.usdt.num_locations = 1;
-  auto attach_points = make_attach_point_list( a );
+  auto attach_points = make_attach_point_list(a);
   ast::Probe probe(attach_points, nullptr, nullptr);
 
   StrictMock<MockBPFtrace> bpftrace;
@@ -551,7 +554,7 @@ TEST(bpftrace, add_probes_usdt_wildcard)
   a.func = "tp*";
   a.usdt.num_locations = 1;
   a.need_expansion = true;
-  auto attach_points = make_attach_point_list( a );
+  auto attach_points = make_attach_point_list(a);
   ast::Probe probe(attach_points, nullptr, nullptr);
 
   auto bpftrace = get_strict_mock_bpftrace();
@@ -591,7 +594,7 @@ TEST(bpftrace, add_probes_usdt_empty_namespace)
   a.func = "tp1";
   a.usdt.num_locations = 1;
   a.need_expansion = true;
-  auto attach_points = make_attach_point_list( a );
+  auto attach_points = make_attach_point_list(a);
   ast::Probe probe(attach_points, nullptr, nullptr);
 
   auto bpftrace = get_strict_mock_bpftrace();
@@ -616,7 +619,7 @@ TEST(bpftrace, add_probes_usdt_empty_namespace_conflict)
   a.func = "tp";
   a.usdt.num_locations = 1;
   a.need_expansion = true;
-  auto attach_points = make_attach_point_list( a );
+  auto attach_points = make_attach_point_list(a);
   ast::Probe probe(attach_points, nullptr, nullptr);
 
   auto bpftrace = get_strict_mock_bpftrace();
@@ -633,7 +636,7 @@ TEST(bpftrace, add_probes_usdt_duplicate_markers)
   a.ns = "prov1";
   a.func = "mytp";
   a.usdt.num_locations = 3;
-  auto attach_points = make_attach_point_list( a );
+  auto attach_points = make_attach_point_list(a);
   ast::Probe probe(attach_points, nullptr, nullptr);
 
   StrictMock<MockBPFtrace> bpftrace;
@@ -664,7 +667,7 @@ TEST(bpftrace, add_probes_tracepoint)
   a.provider = "tracepoint";
   a.target = "sched";
   a.func = "sched_switch";
-  auto attach_points = make_attach_point_list( a );
+  auto attach_points = make_attach_point_list(a);
   ast::Probe probe(attach_points, nullptr, nullptr);
 
   StrictMock<MockBPFtrace> bpftrace;
@@ -684,7 +687,7 @@ TEST(bpftrace, add_probes_tracepoint_wildcard)
   a.target = "sched";
   a.func = "sched_*";
   a.need_expansion = true;
-  auto attach_points = make_attach_point_list( a );
+  auto attach_points = make_attach_point_list(a);
   ast::Probe probe(attach_points, nullptr, nullptr);
 
   auto bpftrace = get_strict_mock_bpftrace();
@@ -709,7 +712,7 @@ TEST(bpftrace, add_probes_tracepoint_category_wildcard)
   a.target = "sched*";
   a.func = "sched_*";
   a.need_expansion = true;
-  auto attach_points = make_attach_point_list( a );
+  auto attach_points = make_attach_point_list(a);
   ast::Probe probe(attach_points, nullptr, nullptr);
 
   auto bpftrace = get_strict_mock_bpftrace();
@@ -740,7 +743,7 @@ TEST(bpftrace, add_probes_tracepoint_wildcard_no_matches)
   a.target = "typo";
   a.func = "typo_*";
   a.need_expansion = true;
-  auto attach_points = make_attach_point_list( a );
+  auto attach_points = make_attach_point_list(a);
   ast::Probe probe(attach_points, nullptr, nullptr);
 
   auto bpftrace = get_strict_mock_bpftrace();
@@ -759,7 +762,7 @@ TEST(bpftrace, add_probes_profile)
   a.provider = "profile";
   a.target = "ms";
   a.freq = 997;
-  auto attach_points = make_attach_point_list( a );
+  auto attach_points = make_attach_point_list(a);
   ast::Probe probe(attach_points, nullptr, nullptr);
 
   StrictMock<MockBPFtrace> bpftrace;
@@ -778,7 +781,7 @@ TEST(bpftrace, add_probes_interval)
   a.provider = "interval";
   a.target = "s";
   a.freq = 1;
-  auto attach_points = make_attach_point_list( a );
+  auto attach_points = make_attach_point_list(a);
   ast::Probe probe(attach_points, nullptr, nullptr);
 
   StrictMock<MockBPFtrace> bpftrace;
@@ -797,7 +800,7 @@ TEST(bpftrace, add_probes_software)
   a.provider = "software";
   a.target = "faults";
   a.freq = 1000;
-  auto attach_points = make_attach_point_list( a );
+  auto attach_points = make_attach_point_list(a);
   ast::Probe probe(attach_points, nullptr, nullptr);
 
   StrictMock<MockBPFtrace> bpftrace;
@@ -816,7 +819,7 @@ TEST(bpftrace, add_probes_hardware)
   a.provider = "hardware";
   a.target = "cache-references";
   a.freq = 1000000;
-  auto attach_points = make_attach_point_list( a );
+  auto attach_points = make_attach_point_list(a);
   ast::Probe probe(attach_points, nullptr, nullptr);
 
   StrictMock<MockBPFtrace> bpftrace;
@@ -834,7 +837,7 @@ TEST(bpftrace, invalid_provider)
   ast::AttachPoint a("");
   a.provider = "lookatme";
   a.func = "invalid";
-  auto attach_points = make_attach_point_list( a );
+  auto attach_points = make_attach_point_list(a);
   ast::Probe probe(attach_points, nullptr, nullptr);
 
   StrictMock<MockBPFtrace> bpftrace;
@@ -1068,7 +1071,7 @@ TEST_F(bpftrace_btf, add_probes_kfunc)
   ast::AttachPoint b("");
   b.provider = "kretfunc";
   b.target = "func_1";
-  auto attach_points = make_attach_point_list( a, b );
+  auto attach_points = make_attach_point_list(a, b);
   ast::Probe probe(attach_points, nullptr, nullptr);
 
   StrictMock<MockBPFtrace> bpftrace;

--- a/tests/bpftrace.cpp
+++ b/tests/bpftrace.cpp
@@ -116,12 +116,21 @@ void check_special_probe(Probe &p, const std::string &attach_point, const std::s
   EXPECT_EQ(orig_name, p.name);
 }
 
+namespace {
+/* Convenience function to help generate attach point lists for testing */
+template <typename ...Args>
+std::shared_ptr<ast::AttachPointList> make_attach_point_list(Args... args) {
+  const std::vector<std::shared_ptr<ast::AttachPoint>> list = {std::make_shared<ast::AttachPoint>(args)...};
+  return std::make_shared<ast::AttachPointList>(list);
+}
+} // Anonymous namespace
+
 TEST(bpftrace, add_begin_probe)
 {
   ast::AttachPoint a("");
   a.provider = "BEGIN";
-  ast::AttachPointList attach_points = { &a };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
+  auto attach_points = make_attach_point_list( a );
+  ast::Probe probe(attach_points, nullptr, nullptr);
 
   StrictMock<MockBPFtrace> bpftrace;
   ASSERT_EQ(0, bpftrace.add_probe(probe));
@@ -135,8 +144,8 @@ TEST(bpftrace, add_end_probe)
 {
   ast::AttachPoint a("");
   a.provider = "END";
-  ast::AttachPointList attach_points = { &a };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
+  auto attach_points = make_attach_point_list( a );
+  ast::Probe probe(attach_points, nullptr, nullptr);
 
   StrictMock<MockBPFtrace> bpftrace;
   ASSERT_EQ(0, bpftrace.add_probe(probe));
@@ -151,8 +160,8 @@ TEST(bpftrace, add_probes_single)
   ast::AttachPoint a("");
   a.provider = "kprobe";
   a.func = "sys_read";
-  ast::AttachPointList attach_points = { &a };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
+  auto attach_points = make_attach_point_list( a );
+  ast::Probe probe(attach_points, nullptr, nullptr);
 
   StrictMock<MockBPFtrace> bpftrace;
   ASSERT_EQ(0, bpftrace.add_probe(probe));
@@ -170,8 +179,8 @@ TEST(bpftrace, add_probes_multiple)
   ast::AttachPoint a2("");
   a2.provider = "kprobe";
   a2.func = "sys_write";
-  ast::AttachPointList attach_points = { &a1, &a2 };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
+  auto attach_points = make_attach_point_list( a1, a2 );
+  ast::Probe probe(attach_points, nullptr, nullptr);
 
   StrictMock<MockBPFtrace> bpftrace;
   ASSERT_EQ(0, bpftrace.add_probe(probe));
@@ -195,8 +204,8 @@ TEST(bpftrace, add_probes_wildcard)
   ast::AttachPoint a3("");
   a3.provider = "kprobe";
   a3.func = "sys_write";
-  ast::AttachPointList attach_points = { &a1, &a2, &a3 };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
+  auto attach_points = make_attach_point_list( a1, a2, a3 );
+  ast::Probe probe(attach_points, nullptr, nullptr);
 
   auto bpftrace = get_strict_mock_bpftrace();
   EXPECT_CALL(*bpftrace,
@@ -227,8 +236,8 @@ TEST(bpftrace, add_probes_wildcard_no_matches)
   ast::AttachPoint a3("");
   a3.provider = "kprobe";
   a3.func = "sys_write";
-  ast::AttachPointList attach_points = { &a1, &a2, &a3 };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
+  auto attach_points = make_attach_point_list( a1, a2, a3 );
+  ast::Probe probe(attach_points, nullptr, nullptr);
 
   auto bpftrace = get_strict_mock_bpftrace();
   EXPECT_CALL(*bpftrace,
@@ -250,8 +259,8 @@ TEST(bpftrace, add_probes_kernel_module)
   ast::AttachPoint a1("");
   a1.provider = "kprobe";
   a1.func = "func_in_mod";
-  ast::AttachPointList attach_points = { &a1 };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
+  auto attach_points = make_attach_point_list( a1 );
+  ast::Probe probe(attach_points, nullptr, nullptr);
 
   auto bpftrace = get_strict_mock_bpftrace();
   ASSERT_EQ(0, bpftrace->add_probe(probe));
@@ -268,8 +277,8 @@ TEST(bpftrace, add_probes_kernel_module_wildcard)
   a1.provider = "kprobe";
   a1.func = "func_in_mo*";
   a1.need_expansion = true;
-  ast::AttachPointList attach_points = { &a1 };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
+  auto attach_points = make_attach_point_list( a1 );
+  ast::Probe probe(attach_points, nullptr, nullptr);
 
   auto bpftrace = get_strict_mock_bpftrace();
   EXPECT_CALL(*bpftrace,
@@ -292,8 +301,8 @@ TEST(bpftrace, add_probes_offset)
   a.provider = "kprobe";
   a.func = "sys_read";
   a.func_offset = offset;
-  ast::AttachPointList attach_points = { &a };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
+  auto attach_points = make_attach_point_list( a );
+  ast::Probe probe(attach_points, nullptr, nullptr);
 
   StrictMock<MockBPFtrace> bpftrace;
   ASSERT_EQ(0, bpftrace.add_probe(probe));
@@ -311,8 +320,8 @@ TEST(bpftrace, add_probes_uprobe)
   a.provider = "uprobe";
   a.target = "/bin/sh";
   a.func = "foo";
-  ast::AttachPointList attach_points = { &a };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
+  auto attach_points = make_attach_point_list( a );
+  ast::Probe probe(attach_points, nullptr, nullptr);
 
   StrictMock<MockBPFtrace> bpftrace;
 
@@ -329,8 +338,8 @@ TEST(bpftrace, add_probes_uprobe_wildcard)
   a.target = "/bin/sh";
   a.func = "*open";
   a.need_expansion = true;
-  ast::AttachPointList attach_points = { &a };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
+  auto attach_points = make_attach_point_list( a );
+  ast::Probe probe(attach_points, nullptr, nullptr);
 
   auto bpftrace = get_strict_mock_bpftrace();
   EXPECT_CALL(*bpftrace, extract_func_symbols_from_path("/bin/sh")).Times(1);
@@ -351,8 +360,8 @@ TEST(bpftrace, add_probes_uprobe_wildcard_file)
   a.target = "/bin/*sh";
   a.func = "first_open";
   a.need_expansion = true;
-  ast::AttachPointList attach_points = { &a };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
+  auto attach_points = make_attach_point_list( a );
+  ast::Probe probe(attach_points, nullptr, nullptr);
 
   auto bpftrace = get_strict_mock_bpftrace();
   EXPECT_CALL(*bpftrace, extract_func_symbols_from_path("/bin/*sh")).Times(1);
@@ -375,8 +384,8 @@ TEST(bpftrace, add_probes_uprobe_wildcard_no_matches)
   a.target = "/bin/sh";
   a.func = "foo*";
   a.need_expansion = true;
-  ast::AttachPointList attach_points = { &a };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
+  auto attach_points = make_attach_point_list( a );
+  ast::Probe probe(attach_points, nullptr, nullptr);
 
   auto bpftrace = get_strict_mock_bpftrace();
   EXPECT_CALL(*bpftrace, extract_func_symbols_from_path("/bin/sh")).Times(1);
@@ -392,8 +401,8 @@ TEST(bpftrace, add_probes_uprobe_string_literal)
   a.provider = "uprobe";
   a.target = "/bin/sh";
   a.func = "foo*";
-  ast::AttachPointList attach_points = { &a };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
+  auto attach_points = make_attach_point_list( a );
+  ast::Probe probe(attach_points, nullptr, nullptr);
 
   StrictMock<MockBPFtrace> bpftrace;
 
@@ -409,8 +418,8 @@ TEST(bpftrace, add_probes_uprobe_address)
   a.provider = "uprobe";
   a.target = "/bin/sh";
   a.address = 1024;
-  ast::AttachPointList attach_points = { &a };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
+  auto attach_points = make_attach_point_list( a );
+  ast::Probe probe(attach_points, nullptr, nullptr);
 
   StrictMock<MockBPFtrace> bpftrace;
 
@@ -427,8 +436,8 @@ TEST(bpftrace, add_probes_uprobe_string_offset)
   a.target = "/bin/sh";
   a.func = "foo";
   a.func_offset = 10;
-  ast::AttachPointList attach_points = { &a };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
+  auto attach_points = make_attach_point_list( a );
+  ast::Probe probe(attach_points, nullptr, nullptr);
 
   StrictMock<MockBPFtrace> bpftrace;
 
@@ -447,8 +456,8 @@ TEST(bpftrace, add_probes_uprobe_cpp_symbol)
     a.target = "/bin/sh";
     a.func = "cpp_mangled";
     a.need_expansion = true;
-    ast::AttachPointList attach_points = { &a };
-    ast::Probe probe(&attach_points, nullptr, nullptr);
+    auto attach_points = make_attach_point_list( a );
+    ast::Probe probe(attach_points, nullptr, nullptr);
 
     auto bpftrace = get_strict_mock_bpftrace();
     EXPECT_CALL(*bpftrace, extract_func_symbols_from_path("/bin/sh")).Times(1);
@@ -471,8 +480,8 @@ TEST(bpftrace, add_probes_uprobe_cpp_symbol_full)
   a.target = "/bin/sh";
   a.func = "cpp_mangled(int)";
   a.need_expansion = true;
-  ast::AttachPointList attach_points = { &a };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
+  auto attach_points = make_attach_point_list( a );
+  ast::Probe probe(attach_points, nullptr, nullptr);
 
   auto bpftrace = get_strict_mock_bpftrace();
   EXPECT_CALL(*bpftrace, extract_func_symbols_from_path("/bin/sh")).Times(1);
@@ -493,8 +502,8 @@ TEST(bpftrace, add_probes_uprobe_cpp_symbol_wildcard)
   a.target = "/bin/sh";
   a.func = "cpp_man*";
   a.need_expansion = true;
-  ast::AttachPointList attach_points = { &a };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
+  auto attach_points = make_attach_point_list( a );
+  ast::Probe probe(attach_points, nullptr, nullptr);
 
   auto bpftrace = get_strict_mock_bpftrace();
   EXPECT_CALL(*bpftrace, extract_func_symbols_from_path("/bin/sh")).Times(1);
@@ -520,8 +529,8 @@ TEST(bpftrace, add_probes_usdt)
   a.ns = "prov1";
   a.func = "mytp";
   a.usdt.num_locations = 1;
-  ast::AttachPointList attach_points = { &a };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
+  auto attach_points = make_attach_point_list( a );
+  ast::Probe probe(attach_points, nullptr, nullptr);
 
   StrictMock<MockBPFtrace> bpftrace;
 
@@ -542,8 +551,8 @@ TEST(bpftrace, add_probes_usdt_wildcard)
   a.func = "tp*";
   a.usdt.num_locations = 1;
   a.need_expansion = true;
-  ast::AttachPointList attach_points = { &a };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
+  auto attach_points = make_attach_point_list( a );
+  ast::Probe probe(attach_points, nullptr, nullptr);
 
   auto bpftrace = get_strict_mock_bpftrace();
   EXPECT_CALL(*bpftrace, get_symbols_from_usdt(0, "/bin/*sh")).Times(1);
@@ -582,8 +591,8 @@ TEST(bpftrace, add_probes_usdt_empty_namespace)
   a.func = "tp1";
   a.usdt.num_locations = 1;
   a.need_expansion = true;
-  ast::AttachPointList attach_points = { &a };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
+  auto attach_points = make_attach_point_list( a );
+  ast::Probe probe(attach_points, nullptr, nullptr);
 
   auto bpftrace = get_strict_mock_bpftrace();
   EXPECT_CALL(*bpftrace, get_symbols_from_usdt(0, "/bin/sh")).Times(1);
@@ -607,8 +616,8 @@ TEST(bpftrace, add_probes_usdt_empty_namespace_conflict)
   a.func = "tp";
   a.usdt.num_locations = 1;
   a.need_expansion = true;
-  ast::AttachPointList attach_points = { &a };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
+  auto attach_points = make_attach_point_list( a );
+  ast::Probe probe(attach_points, nullptr, nullptr);
 
   auto bpftrace = get_strict_mock_bpftrace();
   EXPECT_CALL(*bpftrace, get_symbols_from_usdt(0, "/bin/sh")).Times(1);
@@ -624,8 +633,8 @@ TEST(bpftrace, add_probes_usdt_duplicate_markers)
   a.ns = "prov1";
   a.func = "mytp";
   a.usdt.num_locations = 3;
-  ast::AttachPointList attach_points = { &a };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
+  auto attach_points = make_attach_point_list( a );
+  ast::Probe probe(attach_points, nullptr, nullptr);
 
   StrictMock<MockBPFtrace> bpftrace;
 
@@ -655,8 +664,8 @@ TEST(bpftrace, add_probes_tracepoint)
   a.provider = "tracepoint";
   a.target = "sched";
   a.func = "sched_switch";
-  ast::AttachPointList attach_points = { &a };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
+  auto attach_points = make_attach_point_list( a );
+  ast::Probe probe(attach_points, nullptr, nullptr);
 
   StrictMock<MockBPFtrace> bpftrace;
 
@@ -675,8 +684,8 @@ TEST(bpftrace, add_probes_tracepoint_wildcard)
   a.target = "sched";
   a.func = "sched_*";
   a.need_expansion = true;
-  ast::AttachPointList attach_points = { &a };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
+  auto attach_points = make_attach_point_list( a );
+  ast::Probe probe(attach_points, nullptr, nullptr);
 
   auto bpftrace = get_strict_mock_bpftrace();
   std::set<std::string> matches = { "sched_one", "sched_two" };
@@ -700,8 +709,8 @@ TEST(bpftrace, add_probes_tracepoint_category_wildcard)
   a.target = "sched*";
   a.func = "sched_*";
   a.need_expansion = true;
-  ast::AttachPointList attach_points = { &a };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
+  auto attach_points = make_attach_point_list( a );
+  ast::Probe probe(attach_points, nullptr, nullptr);
 
   auto bpftrace = get_strict_mock_bpftrace();
   EXPECT_CALL(*bpftrace,
@@ -731,8 +740,8 @@ TEST(bpftrace, add_probes_tracepoint_wildcard_no_matches)
   a.target = "typo";
   a.func = "typo_*";
   a.need_expansion = true;
-  ast::AttachPointList attach_points = { &a };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
+  auto attach_points = make_attach_point_list( a );
+  ast::Probe probe(attach_points, nullptr, nullptr);
 
   auto bpftrace = get_strict_mock_bpftrace();
   EXPECT_CALL(*bpftrace,
@@ -750,8 +759,8 @@ TEST(bpftrace, add_probes_profile)
   a.provider = "profile";
   a.target = "ms";
   a.freq = 997;
-  ast::AttachPointList attach_points = { &a };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
+  auto attach_points = make_attach_point_list( a );
+  ast::Probe probe(attach_points, nullptr, nullptr);
 
   StrictMock<MockBPFtrace> bpftrace;
 
@@ -769,8 +778,8 @@ TEST(bpftrace, add_probes_interval)
   a.provider = "interval";
   a.target = "s";
   a.freq = 1;
-  ast::AttachPointList attach_points = { &a };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
+  auto attach_points = make_attach_point_list( a );
+  ast::Probe probe(attach_points, nullptr, nullptr);
 
   StrictMock<MockBPFtrace> bpftrace;
 
@@ -788,8 +797,8 @@ TEST(bpftrace, add_probes_software)
   a.provider = "software";
   a.target = "faults";
   a.freq = 1000;
-  ast::AttachPointList attach_points = { &a };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
+  auto attach_points = make_attach_point_list( a );
+  ast::Probe probe(attach_points, nullptr, nullptr);
 
   StrictMock<MockBPFtrace> bpftrace;
 
@@ -807,8 +816,8 @@ TEST(bpftrace, add_probes_hardware)
   a.provider = "hardware";
   a.target = "cache-references";
   a.freq = 1000000;
-  ast::AttachPointList attach_points = { &a };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
+  auto attach_points = make_attach_point_list( a );
+  ast::Probe probe(attach_points, nullptr, nullptr);
 
   StrictMock<MockBPFtrace> bpftrace;
 
@@ -825,8 +834,8 @@ TEST(bpftrace, invalid_provider)
   ast::AttachPoint a("");
   a.provider = "lookatme";
   a.func = "invalid";
-  ast::AttachPointList attach_points = { &a };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
+  auto attach_points = make_attach_point_list( a );
+  ast::Probe probe(attach_points, nullptr, nullptr);
 
   StrictMock<MockBPFtrace> bpftrace;
 
@@ -1059,8 +1068,8 @@ TEST_F(bpftrace_btf, add_probes_kfunc)
   ast::AttachPoint b("");
   b.provider = "kretfunc";
   b.target = "func_1";
-  ast::AttachPointList attach_points = { &a, &b };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
+  auto attach_points = make_attach_point_list( a, b );
+  ast::Probe probe(attach_points, nullptr, nullptr);
 
   StrictMock<MockBPFtrace> bpftrace;
 

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -866,7 +866,8 @@ TEST(semantic_analyser, variable_type)
   Driver driver(bpftrace);
   test(driver, "kprobe:f { $x = 1 }", 0);
   auto st = CreateInt64();
-  auto assignment = std::static_pointer_cast<ast::AssignVarStatement>(driver.root_->probes->at(0)->stmts->at(0));
+  auto assignment = std::static_pointer_cast<ast::AssignVarStatement>(
+      driver.root_->probes->at(0)->stmts->at(0));
   EXPECT_EQ(st, assignment->var->type);
 }
 
@@ -895,8 +896,10 @@ TEST(semantic_analyser, map_integer_sizes)
   std::string structs = "struct type1 { int x; }";
   test(driver, structs + "kprobe:f { $x = ((struct type1)0).x; @x = $x; }", 0);
 
-  auto var_assignment = std::static_pointer_cast<ast::AssignVarStatement>(driver.root_->probes->at(0)->stmts->at(0));
-  auto map_assignment = std::static_pointer_cast<ast::AssignMapStatement>(driver.root_->probes->at(0)->stmts->at(1));
+  auto var_assignment = std::static_pointer_cast<ast::AssignVarStatement>(
+      driver.root_->probes->at(0)->stmts->at(0));
+  auto map_assignment = std::static_pointer_cast<ast::AssignMapStatement>(
+      driver.root_->probes->at(0)->stmts->at(1));
   EXPECT_EQ(CreateInt32(), var_assignment->var->type);
   EXPECT_EQ(CreateInt64(), map_assignment->map->type);
 }
@@ -1275,7 +1278,8 @@ TEST(semantic_analyser, field_access_is_internal)
   {
     test(driver, structs + "kprobe:f { $x = ((struct type1)0).x }", 0);
     auto stmts = driver.root_->probes->at(0)->stmts;
-    auto var_assignment1 = std::static_pointer_cast<ast::AssignVarStatement >(stmts->at(0));
+    auto var_assignment1 = std::static_pointer_cast<ast::AssignVarStatement>(
+        stmts->at(0));
     EXPECT_FALSE(var_assignment1->var->type.is_internal);
   }
 
@@ -1284,8 +1288,10 @@ TEST(semantic_analyser, field_access_is_internal)
          structs + "kprobe:f { @type1 = (struct type1)0; $x = @type1.x }",
          0);
     auto stmts = driver.root_->probes->at(0)->stmts;
-    auto map_assignment = std::static_pointer_cast<ast::AssignMapStatement >(stmts->at(0));
-    auto var_assignment2 = std::static_pointer_cast<ast::AssignVarStatement >(stmts->at(1));
+    auto map_assignment = std::static_pointer_cast<ast::AssignMapStatement>(
+        stmts->at(0));
+    auto var_assignment2 = std::static_pointer_cast<ast::AssignVarStatement>(
+        stmts->at(1));
     EXPECT_TRUE(map_assignment->map->type.is_internal);
     EXPECT_TRUE(var_assignment2->var->type.is_internal);
   }
@@ -1448,10 +1454,14 @@ TEST(semantic_analyser, cast_sign)
     "  $s = $t->s; $us = $t->us; $l = $t->l; $lu = $t->ul; }";
   test(driver, prog, 0);
 
-  auto s  = std::static_pointer_cast<ast::AssignVarStatement>(driver.root_->probes->at(0)->stmts->at(1));
-  auto us = std::static_pointer_cast<ast::AssignVarStatement>(driver.root_->probes->at(0)->stmts->at(2));
-  auto l  = std::static_pointer_cast<ast::AssignVarStatement>(driver.root_->probes->at(0)->stmts->at(3));
-  auto ul = std::static_pointer_cast<ast::AssignVarStatement>(driver.root_->probes->at(0)->stmts->at(4));
+  auto s = std::static_pointer_cast<ast::AssignVarStatement>(
+      driver.root_->probes->at(0)->stmts->at(1));
+  auto us = std::static_pointer_cast<ast::AssignVarStatement>(
+      driver.root_->probes->at(0)->stmts->at(2));
+  auto l = std::static_pointer_cast<ast::AssignVarStatement>(
+      driver.root_->probes->at(0)->stmts->at(3));
+  auto ul = std::static_pointer_cast<ast::AssignVarStatement>(
+      driver.root_->probes->at(0)->stmts->at(4));
   EXPECT_EQ(CreateInt32(), s->var->type);
   EXPECT_EQ(CreateUInt32(), us->var->type);
   EXPECT_EQ(CreateInt64(), l->var->type);
@@ -1478,11 +1488,14 @@ TEST(semantic_analyser, binop_sign)
       "}";
 
     test(driver, prog, 0);
-    auto varA = std::static_pointer_cast<ast::AssignVarStatement>(driver.root_->probes->at(0)->stmts->at(1));
+    auto varA = std::static_pointer_cast<ast::AssignVarStatement>(
+        driver.root_->probes->at(0)->stmts->at(1));
     EXPECT_EQ(CreateInt64(), varA->var->type);
-    auto varB = std::static_pointer_cast<ast::AssignVarStatement>(driver.root_->probes->at(0)->stmts->at(2));
+    auto varB = std::static_pointer_cast<ast::AssignVarStatement>(
+        driver.root_->probes->at(0)->stmts->at(2));
     EXPECT_EQ(CreateUInt64(), varB->var->type);
-    auto varC = std::static_pointer_cast<ast::AssignVarStatement>(driver.root_->probes->at(0)->stmts->at(3));
+    auto varC = std::static_pointer_cast<ast::AssignVarStatement>(
+        driver.root_->probes->at(0)->stmts->at(3));
     EXPECT_EQ(CreateUInt64(), varC->var->type);
   }
 }
@@ -1682,13 +1695,15 @@ TEST(semantic_analyser, type_ctx)
   auto &stmts = driver.root_->probes->at(0)->stmts;
 
   // $x = (struct x*)ctx;
-  auto assignment = std::static_pointer_cast<ast::AssignVarStatement>(stmts->at(0));
+  auto assignment = std::static_pointer_cast<ast::AssignVarStatement>(
+      stmts->at(0));
   EXPECT_TRUE(assignment->var->type.IsPtrTy());
 
   // $a = $x->a;
   assignment = std::static_pointer_cast<ast::AssignVarStatement>(stmts->at(1));
   EXPECT_EQ(CreateInt64(), assignment->var->type);
-  auto fieldaccess = std::static_pointer_cast<ast::FieldAccess>(assignment->expr);
+  auto fieldaccess = std::static_pointer_cast<ast::FieldAccess>(
+      assignment->expr);
   EXPECT_EQ(CreateInt64(), fieldaccess->type);
   auto unop = std::static_pointer_cast<ast::Unop>(fieldaccess->expr);
   EXPECT_TRUE(unop->type.IsCtxAccess());
@@ -1698,7 +1713,8 @@ TEST(semantic_analyser, type_ctx)
   // $b = $x->b[0];
   assignment = std::static_pointer_cast<ast::AssignVarStatement>(stmts->at(2));
   EXPECT_EQ(CreateInt16(), assignment->var->type);
-  auto arrayaccess = std::static_pointer_cast<ast::ArrayAccess>(assignment->expr);
+  auto arrayaccess = std::static_pointer_cast<ast::ArrayAccess>(
+      assignment->expr);
   EXPECT_EQ(CreateInt16(), arrayaccess->type);
   fieldaccess = std::static_pointer_cast<ast::FieldAccess>(arrayaccess->expr);
   EXPECT_TRUE(fieldaccess->type.IsCtxAccess());
@@ -1787,7 +1803,8 @@ TEST(semantic_analyser, tuple_assign_var)
   auto &stmts = driver.root_->probes->at(0)->stmts;
 
   // $t = (1, "str");
-  auto assignment = std::static_pointer_cast<ast::AssignVarStatement>(stmts->at(0));
+  auto assignment = std::static_pointer_cast<ast::AssignVarStatement>(
+      stmts->at(0));
   EXPECT_EQ(ty, assignment->var->type);
 
   // $t = (4, "other");
@@ -1806,7 +1823,8 @@ TEST(semantic_analyser, tuple_assign_map)
   auto &stmts = driver.root_->probes->at(0)->stmts;
 
   // $t = (1, 3, 3, 7);
-  auto assignment = std::static_pointer_cast<ast::AssignMapStatement>(stmts->at(0));
+  auto assignment = std::static_pointer_cast<ast::AssignMapStatement>(
+      stmts->at(0));
   ty = CreateTuple(
       { CreateInt64(), CreateUInt64(), CreateUInt64(), CreateUInt64() });
   EXPECT_EQ(ty, assignment->map->type);
@@ -1830,7 +1848,8 @@ TEST(semantic_analyser, tuple_nested)
   auto &stmts = driver.root_->probes->at(0)->stmts;
 
   // $t = (1, "str");
-  auto assignment = std::static_pointer_cast<ast::AssignVarStatement>(stmts->at(0));
+  auto assignment = std::static_pointer_cast<ast::AssignVarStatement>(
+      stmts->at(0));
   EXPECT_EQ(ty, assignment->var->type);
 }
 

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -707,7 +707,7 @@ TEST(semantic_analyser, call_uaddr)
 
   for (size_t i = 0; i < sizes.size(); i++)
   {
-    auto v = static_cast<ast::AssignVarStatement *>(
+    auto v = std::static_pointer_cast<ast::AssignVarStatement>(
         driver.root_->probes->at(0)->stmts->at(i));
     EXPECT_TRUE(v->var->type.IsPtrTy());
     EXPECT_TRUE(v->var->type.GetPointeeTy()->IsIntTy());
@@ -855,7 +855,7 @@ TEST(semantic_analyser, array_access) {
        "struct MyStruct { int y[4]; } kprobe:f { $s = (struct MyStruct *) "
        "arg0; @x = $s->y[0];}",
        0);
-  auto assignment = static_cast<ast::AssignMapStatement *>(
+  auto assignment = std::static_pointer_cast<ast::AssignMapStatement>(
       driver.root_->probes->at(0)->stmts->at(1));
   EXPECT_EQ(CreateInt64(), assignment->map->type);
 }
@@ -866,7 +866,7 @@ TEST(semantic_analyser, variable_type)
   Driver driver(bpftrace);
   test(driver, "kprobe:f { $x = 1 }", 0);
   auto st = CreateInt64();
-  auto assignment = static_cast<ast::AssignVarStatement*>(driver.root_->probes->at(0)->stmts->at(0));
+  auto assignment = std::static_pointer_cast<ast::AssignVarStatement>(driver.root_->probes->at(0)->stmts->at(0));
   EXPECT_EQ(st, assignment->var->type);
 }
 
@@ -895,8 +895,8 @@ TEST(semantic_analyser, map_integer_sizes)
   std::string structs = "struct type1 { int x; }";
   test(driver, structs + "kprobe:f { $x = ((struct type1)0).x; @x = $x; }", 0);
 
-  auto var_assignment = static_cast<ast::AssignVarStatement*>(driver.root_->probes->at(0)->stmts->at(0));
-  auto map_assignment = static_cast<ast::AssignMapStatement*>(driver.root_->probes->at(0)->stmts->at(1));
+  auto var_assignment = std::static_pointer_cast<ast::AssignVarStatement>(driver.root_->probes->at(0)->stmts->at(0));
+  auto map_assignment = std::static_pointer_cast<ast::AssignMapStatement>(driver.root_->probes->at(0)->stmts->at(1));
   EXPECT_EQ(CreateInt32(), var_assignment->var->type);
   EXPECT_EQ(CreateInt64(), map_assignment->map->type);
 }
@@ -1275,7 +1275,7 @@ TEST(semantic_analyser, field_access_is_internal)
   {
     test(driver, structs + "kprobe:f { $x = ((struct type1)0).x }", 0);
     auto stmts = driver.root_->probes->at(0)->stmts;
-    auto var_assignment1 = static_cast<ast::AssignVarStatement *>(stmts->at(0));
+    auto var_assignment1 = std::static_pointer_cast<ast::AssignVarStatement >(stmts->at(0));
     EXPECT_FALSE(var_assignment1->var->type.is_internal);
   }
 
@@ -1284,8 +1284,8 @@ TEST(semantic_analyser, field_access_is_internal)
          structs + "kprobe:f { @type1 = (struct type1)0; $x = @type1.x }",
          0);
     auto stmts = driver.root_->probes->at(0)->stmts;
-    auto map_assignment = static_cast<ast::AssignMapStatement *>(stmts->at(0));
-    auto var_assignment2 = static_cast<ast::AssignVarStatement *>(stmts->at(1));
+    auto map_assignment = std::static_pointer_cast<ast::AssignMapStatement >(stmts->at(0));
+    auto var_assignment2 = std::static_pointer_cast<ast::AssignVarStatement >(stmts->at(1));
     EXPECT_TRUE(map_assignment->map->type.is_internal);
     EXPECT_TRUE(var_assignment2->var->type.is_internal);
   }
@@ -1343,9 +1343,9 @@ TEST(semantic_analyser, positional_parameters)
 
   Driver driver(bpftrace);
   test(driver, "k:f { $1 }", 0);
-  auto stmt = static_cast<ast::ExprStatement *>(
+  auto stmt = std::static_pointer_cast<ast::ExprStatement>(
       driver.root_->probes->at(0)->stmts->at(0));
-  auto pp = static_cast<ast::PositionalParameter *>(stmt->expr);
+  auto pp = std::static_pointer_cast<ast::PositionalParameter>(stmt->expr);
   EXPECT_EQ(CreateInt64(), pp->type);
   EXPECT_TRUE(pp->is_literal);
 
@@ -1448,10 +1448,10 @@ TEST(semantic_analyser, cast_sign)
     "  $s = $t->s; $us = $t->us; $l = $t->l; $lu = $t->ul; }";
   test(driver, prog, 0);
 
-  auto s  = static_cast<ast::AssignVarStatement*>(driver.root_->probes->at(0)->stmts->at(1));
-  auto us = static_cast<ast::AssignVarStatement*>(driver.root_->probes->at(0)->stmts->at(2));
-  auto l  = static_cast<ast::AssignVarStatement*>(driver.root_->probes->at(0)->stmts->at(3));
-  auto ul = static_cast<ast::AssignVarStatement*>(driver.root_->probes->at(0)->stmts->at(4));
+  auto s  = std::static_pointer_cast<ast::AssignVarStatement>(driver.root_->probes->at(0)->stmts->at(1));
+  auto us = std::static_pointer_cast<ast::AssignVarStatement>(driver.root_->probes->at(0)->stmts->at(2));
+  auto l  = std::static_pointer_cast<ast::AssignVarStatement>(driver.root_->probes->at(0)->stmts->at(3));
+  auto ul = std::static_pointer_cast<ast::AssignVarStatement>(driver.root_->probes->at(0)->stmts->at(4));
   EXPECT_EQ(CreateInt32(), s->var->type);
   EXPECT_EQ(CreateUInt32(), us->var->type);
   EXPECT_EQ(CreateInt64(), l->var->type);
@@ -1478,11 +1478,11 @@ TEST(semantic_analyser, binop_sign)
       "}";
 
     test(driver, prog, 0);
-    auto varA = static_cast<ast::AssignVarStatement*>(driver.root_->probes->at(0)->stmts->at(1));
+    auto varA = std::static_pointer_cast<ast::AssignVarStatement>(driver.root_->probes->at(0)->stmts->at(1));
     EXPECT_EQ(CreateInt64(), varA->var->type);
-    auto varB = static_cast<ast::AssignVarStatement*>(driver.root_->probes->at(0)->stmts->at(2));
+    auto varB = std::static_pointer_cast<ast::AssignVarStatement>(driver.root_->probes->at(0)->stmts->at(2));
     EXPECT_EQ(CreateUInt64(), varB->var->type);
-    auto varC = static_cast<ast::AssignVarStatement*>(driver.root_->probes->at(0)->stmts->at(3));
+    auto varC = std::static_pointer_cast<ast::AssignVarStatement>(driver.root_->probes->at(0)->stmts->at(3));
     EXPECT_EQ(CreateUInt64(), varC->var->type);
   }
 }
@@ -1682,55 +1682,55 @@ TEST(semantic_analyser, type_ctx)
   auto &stmts = driver.root_->probes->at(0)->stmts;
 
   // $x = (struct x*)ctx;
-  auto assignment = static_cast<ast::AssignVarStatement *>(stmts->at(0));
+  auto assignment = std::static_pointer_cast<ast::AssignVarStatement>(stmts->at(0));
   EXPECT_TRUE(assignment->var->type.IsPtrTy());
 
   // $a = $x->a;
-  assignment = static_cast<ast::AssignVarStatement *>(stmts->at(1));
+  assignment = std::static_pointer_cast<ast::AssignVarStatement>(stmts->at(1));
   EXPECT_EQ(CreateInt64(), assignment->var->type);
-  auto fieldaccess = static_cast<ast::FieldAccess *>(assignment->expr);
+  auto fieldaccess = std::static_pointer_cast<ast::FieldAccess>(assignment->expr);
   EXPECT_EQ(CreateInt64(), fieldaccess->type);
-  auto unop = static_cast<ast::Unop *>(fieldaccess->expr);
+  auto unop = std::static_pointer_cast<ast::Unop>(fieldaccess->expr);
   EXPECT_TRUE(unop->type.IsCtxAccess());
-  auto var = static_cast<ast::Variable *>(unop->expr);
+  auto var = std::static_pointer_cast<ast::Variable>(unop->expr);
   EXPECT_TRUE(var->type.IsPtrTy());
 
   // $b = $x->b[0];
-  assignment = static_cast<ast::AssignVarStatement *>(stmts->at(2));
+  assignment = std::static_pointer_cast<ast::AssignVarStatement>(stmts->at(2));
   EXPECT_EQ(CreateInt16(), assignment->var->type);
-  auto arrayaccess = static_cast<ast::ArrayAccess *>(assignment->expr);
+  auto arrayaccess = std::static_pointer_cast<ast::ArrayAccess>(assignment->expr);
   EXPECT_EQ(CreateInt16(), arrayaccess->type);
-  fieldaccess = static_cast<ast::FieldAccess *>(arrayaccess->expr);
+  fieldaccess = std::static_pointer_cast<ast::FieldAccess>(arrayaccess->expr);
   EXPECT_TRUE(fieldaccess->type.IsCtxAccess());
-  unop = static_cast<ast::Unop *>(fieldaccess->expr);
+  unop = std::static_pointer_cast<ast::Unop>(fieldaccess->expr);
   EXPECT_TRUE(unop->type.IsCtxAccess());
-  var = static_cast<ast::Variable *>(unop->expr);
+  var = std::static_pointer_cast<ast::Variable>(unop->expr);
   EXPECT_TRUE(var->type.IsPtrTy());
 
   // $c = $x->c.c;
-  assignment = static_cast<ast::AssignVarStatement *>(stmts->at(3));
+  assignment = std::static_pointer_cast<ast::AssignVarStatement>(stmts->at(3));
   EXPECT_EQ(CreateInt8(), assignment->var->type);
-  fieldaccess = static_cast<ast::FieldAccess *>(assignment->expr);
+  fieldaccess = std::static_pointer_cast<ast::FieldAccess>(assignment->expr);
   EXPECT_EQ(CreateInt8(), fieldaccess->type);
-  fieldaccess = static_cast<ast::FieldAccess *>(fieldaccess->expr);
+  fieldaccess = std::static_pointer_cast<ast::FieldAccess>(fieldaccess->expr);
   EXPECT_TRUE(fieldaccess->type.IsCtxAccess());
-  unop = static_cast<ast::Unop *>(fieldaccess->expr);
+  unop = std::static_pointer_cast<ast::Unop>(fieldaccess->expr);
   EXPECT_TRUE(unop->type.IsCtxAccess());
-  var = static_cast<ast::Variable *>(unop->expr);
+  var = std::static_pointer_cast<ast::Variable>(unop->expr);
   EXPECT_TRUE(var->type.IsPtrTy());
 
   // $d = $x->d->c;
-  assignment = static_cast<ast::AssignVarStatement *>(stmts->at(4));
+  assignment = std::static_pointer_cast<ast::AssignVarStatement>(stmts->at(4));
   EXPECT_EQ(CreateInt8(), assignment->var->type);
-  fieldaccess = static_cast<ast::FieldAccess *>(assignment->expr);
+  fieldaccess = std::static_pointer_cast<ast::FieldAccess>(assignment->expr);
   EXPECT_EQ(CreateInt8(), fieldaccess->type);
-  unop = static_cast<ast::Unop *>(fieldaccess->expr);
+  unop = std::static_pointer_cast<ast::Unop>(fieldaccess->expr);
   EXPECT_TRUE(unop->type.IsRecordTy());
-  fieldaccess = static_cast<ast::FieldAccess *>(unop->expr);
+  fieldaccess = std::static_pointer_cast<ast::FieldAccess>(unop->expr);
   EXPECT_TRUE(fieldaccess->type.IsPtrTy());
-  unop = static_cast<ast::Unop *>(fieldaccess->expr);
+  unop = std::static_pointer_cast<ast::Unop>(fieldaccess->expr);
   EXPECT_TRUE(unop->type.IsCtxAccess());
-  var = static_cast<ast::Variable *>(unop->expr);
+  var = std::static_pointer_cast<ast::Variable>(unop->expr);
   EXPECT_TRUE(var->type.IsPtrTy());
 
   test(driver, "k:f, kr:f { @ = (uint64)ctx; }", 0);
@@ -1787,11 +1787,11 @@ TEST(semantic_analyser, tuple_assign_var)
   auto &stmts = driver.root_->probes->at(0)->stmts;
 
   // $t = (1, "str");
-  auto assignment = static_cast<ast::AssignVarStatement *>(stmts->at(0));
+  auto assignment = std::static_pointer_cast<ast::AssignVarStatement>(stmts->at(0));
   EXPECT_EQ(ty, assignment->var->type);
 
   // $t = (4, "other");
-  assignment = static_cast<ast::AssignVarStatement *>(stmts->at(1));
+  assignment = std::static_pointer_cast<ast::AssignVarStatement>(stmts->at(1));
   EXPECT_EQ(ty, assignment->var->type);
 }
 
@@ -1806,13 +1806,13 @@ TEST(semantic_analyser, tuple_assign_map)
   auto &stmts = driver.root_->probes->at(0)->stmts;
 
   // $t = (1, 3, 3, 7);
-  auto assignment = static_cast<ast::AssignMapStatement *>(stmts->at(0));
+  auto assignment = std::static_pointer_cast<ast::AssignMapStatement>(stmts->at(0));
   ty = CreateTuple(
       { CreateInt64(), CreateUInt64(), CreateUInt64(), CreateUInt64() });
   EXPECT_EQ(ty, assignment->map->type);
 
   // $t = (0, 0, 0, 0);
-  assignment = static_cast<ast::AssignMapStatement *>(stmts->at(1));
+  assignment = std::static_pointer_cast<ast::AssignMapStatement>(stmts->at(1));
   ty = CreateTuple(
       { CreateInt64(), CreateInt64(), CreateInt64(), CreateInt64() });
   EXPECT_EQ(ty, assignment->map->type);
@@ -1830,7 +1830,7 @@ TEST(semantic_analyser, tuple_nested)
   auto &stmts = driver.root_->probes->at(0)->stmts;
 
   // $t = (1, "str");
-  auto assignment = static_cast<ast::AssignVarStatement *>(stmts->at(0));
+  auto assignment = std::static_pointer_cast<ast::AssignVarStatement>(stmts->at(0));
   EXPECT_EQ(ty, assignment->var->type);
 }
 


### PR DESCRIPTION
An attempt at fixing the memory leak issue during Bison parsing.

Just making a dummy pull request to see if the CI runs.

##### Checklist

- [x] Language changes are updated in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
